### PR TITLE
feat(pdfium): add macOS and musl platform support, disable Docker cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,10 @@ __pycache__/
 *.exe
 *.pdb
 
-# Editor / IDE
+# Editor / IDE / AI
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 *~

--- a/pdfium/README.md
+++ b/pdfium/README.md
@@ -53,7 +53,7 @@ The build pipeline (inspired by [bblanchon/pdfium-binaries](https://github.com/b
 2. Configure gclient with `checkout_configuration=small` (skips V8, test deps, cipd)
 3. Checkout PDFium source at the target chromium branch
 4. Install build dependencies and target architecture sysroot
-5. Apply platform patch from `patches/<platform>.sh`
+5. Apply platform patch from `patches/<platform>.py`
 6. Configure GN args and generate build files
 7. Build with ninja
 8. Verify output binary
@@ -179,18 +179,24 @@ PDFium is compiled with these GN arguments:
 | `target_cpu` | `"x64"` / `"arm64"` | Target architecture |
 | `target_os` | `"linux"` | Target operating system |
 
-The `BUILD.gn` is patched to change the `component("pdfium")` target to `shared_library("pdfium")` so the output is a `.so` rather than a static archive.
-
 ### Platform patches
 
-Platform-specific patches live in `patches/<platform>.sh`. The `--platform` flag selects which patch script to apply during the build (default: `linux`).
+Platform-specific patches live in `patches/<platform>.py`. The `--platform` flag selects which patch script to apply during the build (default: `linux`). Each patch script receives the PDFium source directory as its first argument.
 
 ```
 patches/
-  linux.sh     # shared_library patch for Linux .so output
+  linux.py     # Linux shared library patches
 ```
 
-To add a new platform, create a `patches/<name>.sh` script and add the name to the `PLATFORMS` list in `build_pdfium.py`. The script receives the PDFium source directory as its first argument.
+The Linux patch applies two changes required to produce a `.so` with exported `FPDF_*` symbols:
+
+1. **BUILD.gn** — changes `component("pdfium")` to `shared_library("pdfium")`. The `component()` macro resolves to `static_library` when `is_component_build=false`, so without this patch the output would be a `.a` archive instead of a `.so`.
+
+2. **fpdfview.h** — removes the `#if defined(COMPONENT_BUILD)` guard around `FPDF_EXPORT`. PDFium only applies `__attribute__((visibility("default")))` to its public API when `COMPONENT_BUILD` is defined. Since we set `is_component_build=false` (to get a single `.so` instead of many small ones), `FPDF_EXPORT` resolves to nothing without this patch, and all `FPDF_*` symbols get hidden visibility — making the library unusable via `dlopen`/`dlsym`.
+
+These patches match the approach used by [bblanchon/pdfium-binaries](https://github.com/bblanchon/pdfium-binaries) (`shared_library.patch` + `public_headers.patch`).
+
+To add a new platform, create a `patches/<name>.py` script and add the name to the `PLATFORMS` list in `build_pdfium.py`.
 
 ## Testing
 

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Build PDFium shared libraries for Linux amd64 and arm64 using Docker.
+"""Build PDFium shared libraries for Linux and macOS using Docker.
 
 Compiles PDFium from source by spinning up temporary Docker containers
-for each target architecture. The resulting libpdfium.so binaries can
-optionally be uploaded as GitHub Releases to libviprs/libviprs-dep.
+for each target architecture. Linux builds produce libpdfium.so, macOS
+builds cross-compile from Linux and produce libpdfium.dylib. Binaries
+can optionally be uploaded as GitHub Releases to libviprs/libviprs-dep.
 
 Requirements:
     - Docker with buildx support
@@ -15,6 +16,8 @@ Usage:
     python3 build_pdfium.py 7725 --arch amd64       # build amd64 only
     python3 build_pdfium.py 7725 --arch arm64       # build arm64 only
     python3 build_pdfium.py 7725 --platform linux   # explicit platform (default)
+    python3 build_pdfium.py 7725 --platform mac     # build for macOS
+    python3 build_pdfium.py 7725 --platform musl    # build for musl/Alpine
     python3 build_pdfium.py 7725 --upload           # build and upload to GitHub
 """
 
@@ -42,12 +45,12 @@ except ImportError:
 
 GITHUB_REPO = "libviprs/libviprs-dep"
 
-# Directory containing per-platform patch scripts (e.g. patches/linux.sh).
+# Directory containing per-platform patch scripts (e.g. patches/linux.py).
 PATCHES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "patches")
 
-# Supported platforms.  Each platform has a patch script in patches/<name>.sh
+# Supported platforms.  Each platform has a patch script in patches/<name>.py
 # that is copied into the Docker build context and run against the PDFium source.
-PLATFORMS = ["linux"]
+PLATFORMS = ["linux", "mac", "musl"]
 
 # Target architectures.  All builds run inside an amd64 Docker container
 # and cross-compile for arm64 using PDFium's built-in sysroot + clang.
@@ -66,21 +69,41 @@ TARGETS = {
 # use_custom_libcxx         — bundle libc++ so .so is portable across distros
 # pdf_use_partition_alloc   — skip complex allocator (fails on some platforms)
 # clang_use_chrome_plugins  — skip Chrome's custom clang plugins
-GN_ARGS_TEMPLATE = """\
+GN_ARGS_COMMON = """\
 is_debug = false
 pdf_is_standalone = true
 pdf_enable_v8 = false
 pdf_enable_xfa = false
 is_component_build = false
 treat_warnings_as_errors = false
-use_custom_libcxx = true
 pdf_use_skia = false
 pdf_use_partition_alloc = false
 clang_use_chrome_plugins = false
-target_os = "linux"
 target_cpu = "{gn_cpu}"
 {extra_args}
 """
+
+# Per-platform GN args appended to GN_ARGS_COMMON.
+GN_ARGS_PLATFORM = {
+    "linux": 'target_os = "linux"\nuse_custom_libcxx = true',
+    "mac": 'target_os = "mac"',
+    "musl": (
+        'target_os = "linux"\n'
+        "is_musl = true\n"
+        "is_clang = false\n"
+        "use_custom_libcxx = false\n"
+        "use_custom_libcxx_for_host = false\n"
+        "use_glib = false"
+    ),
+}
+
+
+def gn_args_for(plat, gn_cpu, extra_args):
+    """Build the full GN args string for a platform + architecture."""
+    platform_args = GN_ARGS_PLATFORM.get(plat, "")
+    all_extra = "\n".join(filter(None, [platform_args, extra_args]))
+    return GN_ARGS_COMMON.format(gn_cpu=gn_cpu, extra_args=all_extra)
+
 
 # arm64: disable Branch Target Identification enforcement — the Debian
 # Bullseye sysroot's CRT objects (crti.o, crtbeginS.o) weren't compiled
@@ -604,14 +627,23 @@ def make_dockerfile(version, arch, plat):
     is cross-compiled using its built-in clang and a Debian sysroot,
     avoiding slow QEMU emulation entirely.
 
-    The platform patch script (patches/<plat>.sh) is copied into the
+    The platform patch script (patches/<plat>.py) is copied into the
     build context and applied in Step 5.
     """
+    if plat == "mac":
+        return _make_dockerfile_mac(version, arch)
+    if plat == "musl":
+        return _make_dockerfile_musl(version, arch)
+    return _make_dockerfile_linux(version, arch, plat)
+
+
+def _make_dockerfile_linux(version, arch, plat):
+    """Dockerfile for Linux builds (runs in Docker, cross-compiles arm64)."""
     target = TARGETS[arch]
     gn_cpu = target["gn_cpu"]
     branch = f"chromium/{version}"
     extra_args = GN_ARGS_ARM64 if arch == "arm64" else ""
-    gn_args = GN_ARGS_TEMPLATE.format(gn_cpu=gn_cpu, extra_args=extra_args)
+    gn_args = gn_args_for(plat, gn_cpu, extra_args)
 
     # For cross-compilation, install the target arch's cross-compiler
     base_pkgs = "git curl python3 ca-certificates build-essential pkg-config lsb-release sudo file"
@@ -654,8 +686,8 @@ RUN gclient runhooks
 RUN python3 build/linux/sysroot_scripts/install-sysroot.py --arch={gn_cpu}
 
 # Step 5: Apply platform patch
-COPY platform.sh /tmp/platform.sh
-RUN chmod +x /tmp/platform.sh && /tmp/platform.sh /build/pdfium
+COPY platform.py /tmp/platform.py
+RUN python3 /tmp/platform.py /build/pdfium
 
 # Step 6: Configure GN
 RUN mkdir -p out/Release && cat > out/Release/args.gn <<'ARGS'
@@ -669,6 +701,151 @@ RUN ninja -C out/Release pdfium
 RUN ls -lh out/Release/libpdfium.so && file out/Release/libpdfium.so
 
 # Step 9: Stage artifacts into /staging
+COPY LICENSE /tmp/LICENSE
+RUN mkdir -p /staging/lib /staging/include && \\
+    cp out/Release/libpdfium.so /staging/lib/ && \\
+    cp out/Release/args.gn /staging/ && \\
+    cp -r public/*.h /staging/include/ && \\
+    cp /tmp/LICENSE /staging/
+"""
+
+
+def _make_dockerfile_mac(version, arch):
+    """Dockerfile for macOS builds.
+
+    macOS builds cannot run natively inside Docker.  This Dockerfile
+    cross-compiles PDFium for macOS using the Chromium toolchain's clang
+    and the macOS SDK sysroot that gclient downloads.  The host container
+    is still Linux (amd64).
+    """
+    target = TARGETS[arch]
+    gn_cpu = target["gn_cpu"]
+    branch = f"chromium/{version}"
+    gn_args = gn_args_for("mac", gn_cpu, "")
+
+    return f"""\
+FROM debian:bookworm-slim
+
+# Step 0: System dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \\
+    git curl python3 ca-certificates build-essential pkg-config lsb-release sudo file \\
+    && ln -sf /usr/bin/python3 /usr/bin/python \\
+    && rm -rf /var/lib/apt/lists/*
+
+# Step 1: Install depot_tools
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \\
+    /opt/depot_tools
+ENV PATH="/opt/depot_tools:${{PATH}}"
+RUN gclient --version
+ENV DEPOT_TOOLS_UPDATE=0
+
+# Step 2: Configure gclient
+WORKDIR /build
+RUN gclient config --unmanaged https://pdfium.googlesource.com/pdfium.git \\
+    --custom-var "checkout_configuration=small"
+RUN echo "target_os = [ 'mac' ]" >> .gclient
+
+# Step 3: Checkout source at target branch
+RUN gclient sync -r "origin/{branch}" --no-history --shallow
+
+# Step 4: Build dependencies
+WORKDIR /build/pdfium
+RUN gclient runhooks
+
+# Step 5: Apply platform patch
+COPY platform.py /tmp/platform.py
+RUN python3 /tmp/platform.py /build/pdfium
+
+# Step 6: Configure GN
+RUN mkdir -p out/Release && cat > out/Release/args.gn <<'ARGS'
+{gn_args}ARGS
+RUN gn gen out/Release
+
+# Step 7: Build
+RUN ninja -C out/Release pdfium
+
+# Step 8: Verify output
+RUN ls -lh out/Release/libpdfium.dylib && file out/Release/libpdfium.dylib
+
+# Step 9: Stage artifacts into /staging
+COPY LICENSE /tmp/LICENSE
+RUN mkdir -p /staging/lib /staging/include && \\
+    cp out/Release/libpdfium.dylib /staging/lib/ && \\
+    cp out/Release/args.gn /staging/ && \\
+    cp -r public/*.h /staging/include/ && \\
+    cp /tmp/LICENSE /staging/
+"""
+
+
+def _make_dockerfile_musl(version, arch):
+    """Dockerfile for musl (Alpine-compatible) builds.
+
+    Uses musl-cross-make toolchains instead of Chromium's clang.
+    The musl patch script installs a custom GN toolchain definition
+    and patches BUILDCONFIG.gn to route builds through musl-gcc.
+    """
+    target = TARGETS[arch]
+    gn_cpu = target["gn_cpu"]
+    branch = f"chromium/{version}"
+    gn_args = gn_args_for("musl", gn_cpu, "")
+
+    # Map gn_cpu to musl-cross-make target triple prefix
+    musl_targets = {
+        "x64": "x86_64-linux-musl",
+        "arm64": "aarch64-linux-musl",
+    }
+    musl_target = musl_targets[gn_cpu]
+
+    return f"""\
+FROM debian:bookworm-slim
+
+# Step 0: System dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \\
+    git curl python3 ca-certificates build-essential pkg-config lsb-release sudo file \\
+    xz-utils \\
+    && ln -sf /usr/bin/python3 /usr/bin/python \\
+    && rm -rf /var/lib/apt/lists/*
+
+# Step 1: Install musl-cross-make toolchain
+RUN curl -fsSL "https://musl.cc/{musl_target}-cross.tgz" | tar xz -C /opt
+ENV PATH="/opt/{musl_target}-cross/bin:${{PATH}}"
+
+# Step 2: Install depot_tools
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \\
+    /opt/depot_tools
+ENV PATH="/opt/depot_tools:${{PATH}}"
+RUN gclient --version
+ENV DEPOT_TOOLS_UPDATE=0
+
+# Step 3: Configure gclient
+WORKDIR /build
+RUN gclient config --unmanaged https://pdfium.googlesource.com/pdfium.git \\
+    --custom-var "checkout_configuration=small"
+RUN echo "target_os = [ 'linux' ]" >> .gclient
+
+# Step 4: Checkout source at target branch
+RUN gclient sync -r "origin/{branch}" --no-history --shallow
+
+# Step 5: Build dependencies
+WORKDIR /build/pdfium
+RUN gclient runhooks
+
+# Step 6: Apply platform patch
+COPY platform.py /tmp/platform.py
+RUN python3 /tmp/platform.py /build/pdfium
+
+# Step 7: Configure GN
+RUN mkdir -p out/Release && cat > out/Release/args.gn <<'ARGS'
+{gn_args}ARGS
+RUN gn gen out/Release
+
+# Step 8: Build
+RUN ninja -C out/Release pdfium
+
+# Step 9: Verify output
+RUN ls -lh out/Release/libpdfium.so && file out/Release/libpdfium.so
+
+# Step 10: Stage artifacts into /staging
 COPY LICENSE /tmp/LICENSE
 RUN mkdir -p /staging/lib /staging/include && \\
     cp out/Release/libpdfium.so /staging/lib/ && \\
@@ -718,15 +895,15 @@ def build_for_arch(version, arch, plat, output_dir, progress):
     All builds run inside an amd64 container.  arm64 targets are
     cross-compiled using PDFium's clang and a Debian sysroot.
 
-    The platform patch script (patches/<plat>.sh) is copied into the
-    Docker build context as ``platform.sh`` and applied during the build.
+    The platform patch script (patches/<plat>.py) is copied into the
+    Docker build context as ``platform.py`` and applied during the build.
     """
     image_tag = f"pdfium-builder-{version}-{arch}"
     container_name = f"pdfium-extract-{version}-{arch}"
 
     progress.start_arch(arch)
 
-    patch_script = os.path.join(PATCHES_DIR, f"{plat}.sh")
+    patch_script = os.path.join(PATCHES_DIR, f"{plat}.py")
     if not os.path.isfile(patch_script):
         progress.set_failed(arch)
         raise RuntimeError(f"No patch script for platform '{plat}' (expected {patch_script})")
@@ -737,7 +914,7 @@ def build_for_arch(version, arch, plat, output_dir, progress):
             f.write(make_dockerfile(version, arch, plat))
 
         # Copy the platform patch script and LICENSE into the build context
-        shutil.copy2(patch_script, os.path.join(tmpdir, "platform.sh"))
+        shutil.copy2(patch_script, os.path.join(tmpdir, "platform.py"))
         repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         shutil.copy2(
             os.path.join(repo_root, "LICENSE"),
@@ -754,6 +931,7 @@ def build_for_arch(version, arch, plat, output_dir, progress):
         cmd = [
             "docker",
             "build",
+            "--no-cache",
             "--progress=plain",
             "-t",
             image_tag,
@@ -850,7 +1028,7 @@ def upload_release(version, built_files, progress):
             f"PDFium shared library built from source.\n\n"
             f"Source: https://pdfium.googlesource.com/pdfium/+/refs/heads/{branch}\n\n"
             "Build configuration:\n```\n"
-            f"{GN_ARGS_TEMPLATE.format(gn_cpu='<target>', extra_args='')}```",
+            f"{GN_ARGS_COMMON.format(gn_cpu='<target>', extra_args='')}```",
             *built_files,
         ]
     )

--- a/pdfium/patches/linux.py
+++ b/pdfium/patches/linux.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Platform patch for Linux shared library builds.
+
+Two changes are required to produce a .so with exported FPDF_* symbols:
+
+1. Change component("pdfium") to shared_library("pdfium") in BUILD.gn.
+   The component() macro resolves to static_library when
+   is_component_build=false, so without this the output would be a .a
+   archive instead of a .so.
+
+2. Remove the COMPONENT_BUILD guard around FPDF_EXPORT in fpdfview.h.
+   PDFium only defines FPDF_EXPORT (which applies
+   __attribute__((visibility("default")))) when COMPONENT_BUILD is defined.
+   Since we set is_component_build=false (to get a single .so instead of
+   many small ones), FPDF_EXPORT resolves to nothing and all FPDF_*
+   symbols get default-hidden visibility.
+   Removing the guard ensures FPDF_EXPORT always applies
+   visibility("default"), making the public C API accessible via
+   dlopen/dlsym.
+
+These two patches match what bblanchon/pdfium-binaries uses
+(shared_library.patch + public_headers.patch).
+
+Usage:
+    python3 linux.py /path/to/pdfium
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def patch_build_gn(pdfium_dir: Path) -> None:
+    """Patch BUILD.gn: component() -> shared_library()."""
+    build_gn = pdfium_dir / "BUILD.gn"
+    text = build_gn.read_text()
+    updated = text.replace('component("pdfium")', 'shared_library("pdfium")')
+    if updated == text:
+        print('WARNING: component("pdfium") not found in BUILD.gn — already patched?')
+        return
+    build_gn.write_text(updated)
+    print("Applied: BUILD.gn -> shared_library")
+
+
+def patch_fpdfview_h(pdfium_dir: Path) -> None:
+    """Remove the COMPONENT_BUILD guard around FPDF_EXPORT in fpdfview.h.
+
+    Before (simplified):
+        #if defined(COMPONENT_BUILD)
+        // FPDF_EXPORT should be consistent ...
+        // template in testing/fuzzers/BUILD.gn.
+        #if defined(WIN32)
+          ...  // dllexport / dllimport
+        #else
+          ...  // visibility("default")
+        #endif
+        #else
+        #define FPDF_EXPORT
+        #endif  // defined(COMPONENT_BUILD)
+
+    After:
+        #if defined(WIN32)
+          ...  // dllexport / dllimport
+        #else
+          ...  // visibility("default")
+        #endif
+    """
+    fpdfview = pdfium_dir / "public" / "fpdfview.h"
+    text = fpdfview.read_text()
+
+    # Remove the opening guard and its comment lines
+    # Match: #if defined(COMPONENT_BUILD) followed by optional comment lines
+    text = re.sub(
+        r"#if defined\(COMPONENT_BUILD\)\s*\n"
+        r"(// [^\n]*\n)*",
+        "",
+        text,
+    )
+
+    # Remove the #else ... #define FPDF_EXPORT ... #endif block that provides
+    # the empty fallback when COMPONENT_BUILD is not defined.
+    # This block sits between the platform-specific #endif and the next code.
+    text = re.sub(
+        r"#else\s*\n"
+        r"#define FPDF_EXPORT\s*\n"
+        r"#endif\s*//\s*defined\(COMPONENT_BUILD\)\s*\n",
+        "",
+        text,
+    )
+
+    fpdfview.write_text(text)
+    print("Applied: fpdfview.h -> unconditional FPDF_EXPORT")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        pdfium_dir = Path(".")
+    else:
+        pdfium_dir = Path(sys.argv[1])
+
+    if not (pdfium_dir / "BUILD.gn").exists():
+        print(f"Error: {pdfium_dir}/BUILD.gn not found", file=sys.stderr)
+        sys.exit(1)
+
+    patch_build_gn(pdfium_dir)
+    patch_fpdfview_h(pdfium_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/pdfium/patches/mac.py
+++ b/pdfium/patches/mac.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Platform patch for macOS shared library builds (Apple Silicon / x86_64).
+
+Three changes are required to produce a .dylib with exported FPDF_* symbols:
+
+1. Change component("pdfium") to shared_library("pdfium") in BUILD.gn.
+   Same reason as Linux: component() resolves to static_library when
+   is_component_build=false.
+
+2. Remove the COMPONENT_BUILD guard around FPDF_EXPORT in fpdfview.h.
+   Same reason as Linux: ensures FPDF_EXPORT always applies
+   visibility("default") so the public C API is accessible via dlopen/dlsym.
+
+3. Add -Wl,-headerpad_max_install_names to the Apple toolchain linker flags.
+   This reserves space in the Mach-O header for install_name_tool to rewrite
+   the LC_ID_DYLIB path after the build. Without this, the header may not
+   have enough room for longer paths (e.g. when packaging for Homebrew or
+   nixpkgs).
+
+Patches 1 and 2 match bblanchon/pdfium-binaries (shared_library.patch +
+public_headers.patch). Patch 3 matches bblanchon's patches/mac/build.patch.
+
+Usage:
+    python3 mac.py /path/to/pdfium
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def patch_build_gn(pdfium_dir: Path) -> None:
+    """Patch BUILD.gn: component() -> shared_library()."""
+    build_gn = pdfium_dir / "BUILD.gn"
+    text = build_gn.read_text()
+    updated = text.replace('component("pdfium")', 'shared_library("pdfium")')
+    if updated == text:
+        print('WARNING: component("pdfium") not found in BUILD.gn — already patched?')
+        return
+    build_gn.write_text(updated)
+    print("Applied: BUILD.gn -> shared_library")
+
+
+def patch_fpdfview_h(pdfium_dir: Path) -> None:
+    """Remove the COMPONENT_BUILD guard around FPDF_EXPORT in fpdfview.h."""
+    fpdfview = pdfium_dir / "public" / "fpdfview.h"
+    text = fpdfview.read_text()
+
+    # Remove the opening guard and its comment lines
+    text = re.sub(
+        r"#if defined\(COMPONENT_BUILD\)\s*\n"
+        r"(// [^\n]*\n)*",
+        "",
+        text,
+    )
+
+    # Remove the #else ... #define FPDF_EXPORT ... #endif block
+    text = re.sub(
+        r"#else\s*\n"
+        r"#define FPDF_EXPORT\s*\n"
+        r"#endif\s*//\s*defined\(COMPONENT_BUILD\)\s*\n",
+        "",
+        text,
+    )
+
+    fpdfview.write_text(text)
+    print("Applied: fpdfview.h -> unconditional FPDF_EXPORT")
+
+
+def patch_apple_toolchain(pdfium_dir: Path) -> None:
+    """Add -headerpad_max_install_names to the Apple toolchain linker flags.
+
+    This matches bblanchon/pdfium-binaries patches/mac/build.patch.
+    The patch inserts the flag just before the 'link_command' assignment
+    in build/toolchain/apple/toolchain.gni.
+    """
+    toolchain_gni = pdfium_dir / "build" / "toolchain" / "apple" / "toolchain.gni"
+    if not toolchain_gni.exists():
+        print(f"WARNING: {toolchain_gni} not found — skipping headerpad patch")
+        return
+
+    text = toolchain_gni.read_text()
+    marker = 'link_command = "$linker_driver_env $linker_driver"'
+
+    if "-headerpad_max_install_names" in text:
+        print("headerpad patch already applied — skipping")
+        return
+
+    if marker not in text:
+        print(f"WARNING: could not find link_command marker in {toolchain_gni}")
+        return
+
+    patch_lines = '      linker_driver_args += " -Wl,-headerpad_max_install_names"\n\n'
+    updated = text.replace(marker, patch_lines + "      " + marker)
+    toolchain_gni.write_text(updated)
+    print("Applied: toolchain.gni -> headerpad_max_install_names")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        pdfium_dir = Path(".")
+    else:
+        pdfium_dir = Path(sys.argv[1])
+
+    if not (pdfium_dir / "BUILD.gn").exists():
+        print(f"Error: {pdfium_dir}/BUILD.gn not found", file=sys.stderr)
+        sys.exit(1)
+
+    patch_build_gn(pdfium_dir)
+    patch_fpdfview_h(pdfium_dir)
+    patch_apple_toolchain(pdfium_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/pdfium/patches/musl.py
+++ b/pdfium/patches/musl.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Platform patch for musl (Alpine) shared library builds.
+
+Four changes are required on top of the standard Linux patches:
+
+1. Change component("pdfium") to shared_library("pdfium") in BUILD.gn.
+   Same as Linux — component() resolves to static_library when
+   is_component_build=false.
+
+2. Remove the COMPONENT_BUILD guard around FPDF_EXPORT in fpdfview.h.
+   Same as Linux — ensures FPDF_EXPORT always applies
+   visibility("default").
+
+3. Patch build/config/BUILDCONFIG.gn to:
+   - Declare the is_musl GN arg.
+   - Route the default toolchain to //build/toolchain/linux/musl when
+     is_musl is true.
+   - Disable -fstack-protector under musl (musl's __stack_chk_fail is
+     incompatible with the flags Chromium passes).
+
+4. Patch third_party/highway/BUILD.gn to also disable HWY_AVX3_SPR on
+   32-bit builds. Without this, highway emits broken SIMD code on musl
+   x86.
+
+5. Install the musl GN toolchain definition at
+   build/toolchain/linux/musl/BUILD.gn. This defines gcc_toolchain()
+   entries for x86, x64, arm, and arm64 using musl-cross-make prefixed
+   compilers.
+
+All patches match bblanchon/pdfium-binaries (patches/musl/).
+
+Usage:
+    python3 musl.py /path/to/pdfium
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def patch_build_gn(pdfium_dir: Path) -> None:
+    """Patch BUILD.gn: component() -> shared_library()."""
+    build_gn = pdfium_dir / "BUILD.gn"
+    text = build_gn.read_text()
+    updated = text.replace('component("pdfium")', 'shared_library("pdfium")')
+    if updated == text:
+        print('WARNING: component("pdfium") not found in BUILD.gn — already patched?')
+        return
+    build_gn.write_text(updated)
+    print("Applied: BUILD.gn -> shared_library")
+
+
+def patch_fpdfview_h(pdfium_dir: Path) -> None:
+    """Remove the COMPONENT_BUILD guard around FPDF_EXPORT in fpdfview.h."""
+    fpdfview = pdfium_dir / "public" / "fpdfview.h"
+    text = fpdfview.read_text()
+
+    text = re.sub(
+        r"#if defined\(COMPONENT_BUILD\)\s*\n"
+        r"(// [^\n]*\n)*",
+        "",
+        text,
+    )
+
+    text = re.sub(
+        r"#else\s*\n"
+        r"#define FPDF_EXPORT\s*\n"
+        r"#endif\s*//\s*defined\(COMPONENT_BUILD\)\s*\n",
+        "",
+        text,
+    )
+
+    fpdfview.write_text(text)
+    print("Applied: fpdfview.h -> unconditional FPDF_EXPORT")
+
+
+def patch_buildconfig_gn(pdfium_dir: Path) -> None:
+    """Patch build/config/BUILDCONFIG.gn for musl support.
+
+    - Declare is_musl arg (defaults to false).
+    - Route default toolchain to //build/toolchain/linux/musl when is_musl.
+    - Disable -fstack-protector under musl.
+    """
+    buildconfig = pdfium_dir / "build" / "config" / "BUILDCONFIG.gn"
+    if not buildconfig.exists():
+        print(f"WARNING: {buildconfig} not found — skipping")
+        return
+
+    text = buildconfig.read_text()
+
+    # Add is_musl declaration after is_official_build
+    if "is_musl" not in text:
+        text = text.replace(
+            "is_official_build = false",
+            "is_official_build = false\n\n  # Use musl instead of glibc\n  is_musl = false",
+        )
+
+    # Route toolchain: insert musl check before is_clang check
+    toolchain_sections = text.split("_default_toolchain")[1:]
+    already_patched = toolchain_sections and "is_musl" in toolchain_sections[0]
+    if not already_patched:
+        text = text.replace(
+            "  if (is_clang) {\n"
+            '    _default_toolchain = "//build/toolchain/linux:clang_$target_cpu"',
+            "  if (is_musl) {\n"
+            '    _default_toolchain = "//build/toolchain/linux/musl:$target_cpu"\n'
+            "  } else if (is_clang) {\n"
+            '    _default_toolchain = "//build/toolchain/linux:clang_$target_cpu"',
+        )
+
+    # Disable -fstack-protector under musl
+    if "!is_musl" not in text:
+        text = text.replace(
+            "} else if (is_posix || is_fuchsia) {",
+            "} else if ((is_posix && !is_musl) || is_fuchsia) {",
+        )
+
+    buildconfig.write_text(text)
+    print("Applied: BUILDCONFIG.gn -> musl support")
+
+
+def patch_highway_build_gn(pdfium_dir: Path) -> None:
+    """Patch third_party/highway/BUILD.gn to disable HWY_AVX3_SPR on 32-bit."""
+    highway_gn = pdfium_dir / "third_party" / "highway" / "BUILD.gn"
+    if not highway_gn.exists():
+        print(f"WARNING: {highway_gn} not found — skipping")
+        return
+
+    text = highway_gn.read_text()
+    old = 'defines += [ "HWY_BROKEN_TARGETS=(HWY_AVX2|HWY_AVX3)" ]'
+    new = 'defines += [ "HWY_BROKEN_TARGETS=(HWY_AVX2|HWY_AVX3|HWY_AVX3_SPR)" ]'
+
+    if new in text:
+        print("highway patch already applied — skipping")
+        return
+
+    if old not in text:
+        print("WARNING: highway HWY_BROKEN_TARGETS line not found — skipping")
+        return
+
+    text = text.replace(old, new)
+    highway_gn.write_text(text)
+    print("Applied: highway BUILD.gn -> disable HWY_AVX3_SPR")
+
+
+def install_musl_toolchain(pdfium_dir: Path) -> None:
+    """Install the musl GN toolchain definition."""
+    toolchain_dir = pdfium_dir / "build" / "toolchain" / "linux" / "musl"
+    toolchain_dir.mkdir(parents=True, exist_ok=True)
+    toolchain_gn = toolchain_dir / "BUILD.gn"
+
+    toolchain_gn.write_text("""\
+import("//build/toolchain/gcc_toolchain.gni")
+
+gcc_toolchain("x86") {
+  toolprefix = "i686-linux-musl-"
+
+  cc = "${toolprefix}gcc"
+  cxx = "${toolprefix}g++"
+
+  readelf = "${toolprefix}readelf"
+  nm = "${toolprefix}nm"
+  ar = "${toolprefix}ar"
+  ld = cxx
+
+  extra_ldflags = "-static-libgcc -static-libstdc++"
+
+  toolchain_args = {
+    current_cpu = "x86"
+    current_os = "linux"
+
+    use_remoteexec = false
+    is_clang = false
+  }
+}
+
+gcc_toolchain("x64") {
+  toolprefix = "x86_64-linux-musl-"
+
+  cc = "${toolprefix}gcc"
+  cxx = "${toolprefix}g++"
+
+  readelf = "${toolprefix}readelf"
+  nm = "${toolprefix}nm"
+  ar = "${toolprefix}ar"
+  ld = cxx
+
+  extra_ldflags = "-static-libgcc -static-libstdc++"
+
+  toolchain_args = {
+    current_cpu = "x64"
+    current_os = "linux"
+
+    use_remoteexec = false
+    is_clang = false
+  }
+}
+
+gcc_toolchain("arm") {
+  toolprefix = "arm-linux-musleabihf-"
+
+  cc = "${toolprefix}gcc"
+  cxx = "${toolprefix}g++"
+
+  readelf = "${toolprefix}readelf"
+  nm = "${toolprefix}nm"
+  ar = "${toolprefix}ar"
+  ld = cxx
+
+  extra_ldflags = "-static-libgcc -static-libstdc++"
+
+  toolchain_args = {
+    current_cpu = "arm"
+    current_os = "linux"
+
+    use_remoteexec = false
+    is_clang = false
+  }
+}
+
+gcc_toolchain("arm64") {
+  toolprefix = "aarch64-linux-musl-"
+
+  cc = "${toolprefix}gcc"
+  cxx = "${toolprefix}g++"
+
+  readelf = "${toolprefix}readelf"
+  nm = "${toolprefix}nm"
+  ar = "${toolprefix}ar"
+  ld = cxx
+
+  extra_cxxflags= "-flax-vector-conversions"
+  extra_ldflags = "-static-libgcc -static-libstdc++"
+
+  toolchain_args = {
+    current_cpu = "arm64"
+    current_os = "linux"
+
+    use_remoteexec = false
+    is_clang = false
+  }
+}
+""")
+    print(f"Installed: {toolchain_gn}")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        pdfium_dir = Path(".")
+    else:
+        pdfium_dir = Path(sys.argv[1])
+
+    if not (pdfium_dir / "BUILD.gn").exists():
+        print(f"Error: {pdfium_dir}/BUILD.gn not found", file=sys.stderr)
+        sys.exit(1)
+
+    patch_build_gn(pdfium_dir)
+    patch_fpdfview_h(pdfium_dir)
+    patch_buildconfig_gn(pdfium_dir)
+    patch_highway_build_gn(pdfium_dir)
+    install_musl_toolchain(pdfium_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/pdfium/tests/test_dockerfile.py
+++ b/pdfium/tests/test_dockerfile.py
@@ -40,7 +40,7 @@ class TestMakeDockerfileAmd64:
         assert "install-sysroot.py --arch=x64" in self.df
 
     def test_platform_patch_copied(self):
-        assert "COPY platform.sh" in self.df
+        assert "COPY platform.py" in self.df
 
     def test_shared_library_gn_args(self):
         assert "is_component_build = false" in self.df


### PR DESCRIPTION
Add platform patch scripts and Dockerfile generation for macOS (Apple Silicon / x86_64) and musl (Alpine) targets, matching the patches from bblanchon/pdfium-binaries.

macOS support:
- patches/mac.py applies shared_library + FPDF_EXPORT patches (same as Linux) plus the headerpad_max_install_names linker flag in the Apple toolchain, which reserves Mach-O header space for install_name_tool to rewrite LC_ID_DYLIB paths after the build.
- Dockerfile cross-compiles for macOS from a Linux container using Chromium's clang and the macOS SDK sysroot that gclient downloads. Output is libpdfium.dylib instead of .so.

musl support:
- patches/musl.py applies shared_library + FPDF_EXPORT patches, then patches BUILDCONFIG.gn to declare the is_musl arg and route builds through a custom GN toolchain using musl-cross-make compilers. Also disables -fstack-protector (incompatible with musl's __stack_chk_fail) and disables HWY_AVX3_SPR in highway (broken SIMD codegen on 32-bit).
- Installs build/toolchain/linux/musl/BUILD.gn with gcc_toolchain() entries for x86, x64, arm, and arm64.
- Dockerfile pulls musl-cross-make toolchains from musl.cc instead of using Chromium's clang.

Build script changes:
- Refactor GN args into GN_ARGS_COMMON + per-platform overrides so platform-specific flags (use_custom_libcxx, is_musl, is_clang) are only applied where needed.
- Add --no-cache to docker build to ensure clean builds every time. Cached Docker layers were masking the ninja step count on amd64, making it appear as only 20 steps instead of 2000+.
- Migrate patch scripts from shell (linux.sh) to Python (linux.py) for consistency and better error handling across all three platforms.

Also fixes test_dockerfile.py to match the updated Dockerfile template.