### PR TITLE
feat(pdfium): add musl variants and static archives to default matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,30 +5,90 @@ on:
       version:
         description: "PDFium chromium branch number (e.g. 7725)"
         required: true
-      arch:
-        description: "Architecture"
-        required: true
-        type: choice
-        options:
-          - amd64
-          - arm64
+      upload:
+        description: "Create a GitHub Release and attach the archives"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux, musl]
+        arch: [amd64, arm64]
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Two ninja phases per archive (static + shared) plus cross-compile for
+    # arm64 pushes each combo well past the single-phase budget. 90 minutes
+    # gives headroom without letting a hung build loiter forever.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Build PDFium ${{ inputs.arch }}
-        run: python3 pdfium/build_pdfium.py ${{ inputs.version }} --arch ${{ inputs.arch }}
-      - name: Verify output
+      - name: Build PDFium ${{ matrix.platform }}/${{ matrix.arch }}
+        run: >-
+          python3 pdfium/build_pdfium.py ${{ inputs.version }}
+          --platform ${{ matrix.platform }}
+          --arch ${{ matrix.arch }}
+      - name: Verify output contains both .so and .a
         run: |
-          ls -lh pdfium/bin/
-          tar tzf pdfium/bin/pdfium-*.tgz | head -20
+          set -eu
+          cd pdfium/bin
+          ls -lh
+          for f in pdfium-${{ matrix.platform }}-*.tgz; do
+            echo "=== $f ==="
+            tar tzf "$f"
+            tar tzf "$f" | grep -q 'lib/libpdfium.so' || { echo "missing libpdfium.so in $f"; exit 1; }
+            tar tzf "$f" | grep -q 'lib/libpdfium.a'  || { echo "missing libpdfium.a in $f";  exit 1; }
+          done
       - uses: actions/upload-artifact@v4
         with:
-          name: pdfium-linux-${{ inputs.arch }}
+          name: pdfium-${{ matrix.platform }}-${{ matrix.arch }}
           path: pdfium/bin/pdfium-*.tgz
+
+  release:
+    needs: build
+    if: ${{ inputs.upload }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          # download-artifact with a single name extracts to <path>; with
+          # no name and pattern: '*' it downloads every artifact from the
+          # run into <path>/<artifact-name>/, so the tarballs land under
+          # artifacts/pdfium-<plat>-<arch>/pdfium-<plat>-<cpu>.tgz.
+      - name: Flatten artifacts
+        run: |
+          set -eu
+          mkdir -p release-assets
+          find artifacts -name 'pdfium-*.tgz' -exec cp {} release-assets/ \;
+          ls -lh release-assets
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          TAG="pdfium-${{ inputs.version }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release '$TAG' already exists, deleting so this run can replace it..."
+            gh release delete "$TAG" --yes
+          fi
+          gh release create "$TAG" \
+            --title "PDFium chromium/${{ inputs.version }}" \
+            --notes "PDFium libraries built from source.
+
+          Each archive contains:
+          - \`lib/libpdfium.so\` (shared library for \`dlopen\`)
+          - \`lib/libpdfium.a\` (static archive for \`pdfium-render/static\`)
+          - \`include/\` — public C headers
+          - \`args.gn\` / \`args.static.gn\` — GN build arguments used
+
+          Source: https://pdfium.googlesource.com/pdfium/+/refs/heads/chromium/${{ inputs.version }}" \
+            release-assets/pdfium-*.tgz

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,0 +1,320 @@
+# libviprs-dep(1) — Build Tools Manual
+
+A man-page-style reference for the libviprs-dep build tooling. For
+narrative overview and download links, see
+[`pdfium/README.md`](pdfium/README.md) and the
+[repo top-level README](README.md).
+
+```
+NAME          libviprs-dep-build — compile pre-built native dependencies for libviprs
+SECTION       1 (User Commands)
+UPDATED       2026-04-20
+```
+
+---
+
+## NAME
+
+**build_pdfium.py** — build PDFium shared libraries and static archives for
+Linux (glibc), musl/Alpine, and macOS from source inside Docker, and
+optionally publish them as GitHub Releases on `libviprs/libviprs-dep`.
+
+## SYNOPSIS
+
+```
+python3 pdfium/build_pdfium.py VERSION
+                               [--arch {amd64,arm64}]
+                               [--platform PLATFORM [PLATFORM ...]]
+                               [--parallel]
+                               [--upload]
+                               [--output-dir DIR]
+```
+
+`VERSION` is a PDFium chromium branch number (e.g. `7725`). It is
+resolved to `origin/chromium/VERSION` at
+`https://pdfium.googlesource.com/pdfium/`.
+
+## DESCRIPTION
+
+`build_pdfium.py` orchestrates a reproducible PDFium build using only
+Docker, Python, and (for uploads) the `gh` CLI. For each requested
+`(platform, arch)` combination it:
+
+1. Generates a platform-specific Dockerfile on the fly.
+2. Builds an amd64 Docker image that runs the full compile inside the
+   container.
+3. Applies the **base** platform patch (symbol-visibility fixes, plus
+   musl-specific toolchain setup where applicable) and runs `ninja`
+   against `out/Static`, producing `libpdfium.a`.
+4. Applies the **shared** patch on top (rewrites
+   `component("pdfium")` → `shared_library("pdfium")`) and runs `ninja`
+   against `out/Shared`, producing `libpdfium.so`.
+5. Stages both artifacts — along with the public C headers, the two
+   `args.gn` files, and `LICENSE` — into a single directory.
+6. Extracts the staging directory from the container and packages it as
+   `pdfium-{platform}-{gn_cpu}.tgz` in the output directory.
+
+The two-phase ninja build is the cleanest way to emit both a static
+archive and a shared library from a single source checkout without
+duplicating PDFium's large `component("pdfium")` target body inside
+`BUILD.gn`.
+
+### Supported platforms
+
+| Platform | Output artifacts | Intended runtime |
+| --- | --- | --- |
+| `linux` | `libpdfium.so` + `libpdfium.a`, glibc-linked | Debian / Ubuntu / RHEL / mainstream distros |
+| `musl`  | `libpdfium.so` + `libpdfium.a`, musl-linked  | Alpine, musl-based distroless images |
+| `mac`   | `libpdfium.dylib` (single-phase today) | macOS (Apple Silicon and x86_64) |
+
+By default the build matrix is `{linux, musl} × {amd64, arm64}`, which
+produces four archives. macOS is not in the default matrix and must be
+requested explicitly via `--platform mac`.
+
+## OPTIONS
+
+### Positional arguments
+
+**`VERSION`**
+
+:   PDFium chromium branch number, e.g. `7725`. Required.
+
+### Optional arguments
+
+**`--arch {amd64,arm64}`**
+
+:   Build a single target architecture instead of both. Applies to every
+    platform passed via `--platform`. Default: build both architectures.
+
+**`--platform PLATFORM [PLATFORM ...]`**
+
+:   One or more of `linux`, `musl`, `mac`. Default: `linux musl`. Pass a
+    single value (`--platform musl`) or several space-separated values
+    (`--platform linux musl`). Each platform pass runs in sequence.
+
+**`--parallel`**
+
+:   Build the architectures of the current platform in parallel threads.
+    Only affects the `(amd64, arm64)` fan-out within a single platform
+    pass. Platform passes still run sequentially to keep the terminal
+    progress header readable.
+
+**`--upload`**
+
+:   After a successful build, call `gh release create` to publish the
+    archives as a GitHub Release tagged `pdfium-{VERSION}` on
+    `libviprs/libviprs-dep`. If a release with that tag already exists
+    it is deleted and replaced. Requires `gh` to be installed and
+    authenticated (`gh auth login`).
+
+**`--output-dir DIR`**
+
+:   Where to write the `.tgz` archives. Default: `./bin`. Created if it
+    does not already exist.
+
+## FILES
+
+```
+pdfium/
+├── build_pdfium.py            # entry point
+├── bin/                       # default output directory (gitignored)
+│   └── pdfium-<plat>-<cpu>.tgz
+├── patches/
+│   ├── linux.py               # glibc linux patch script (accepts --mode)
+│   ├── mac.py                 # macOS patch script (accepts --mode)
+│   └── musl.py                # musl/Alpine patch script (accepts --mode)
+└── tests/                     # pytest suite for pure-function logic
+
+.github/workflows/
+└── build.yml                  # CI workflow: builds the full matrix on dispatch
+```
+
+Each patch script is copied into the Docker build context as
+`platform.py` before being invoked with `--mode base` (for the static
+build) and `--mode shared` (for the shared build). See
+[`pdfium/README.md`](pdfium/README.md) for the patch script details and
+the GN args used.
+
+## ENVIRONMENT
+
+**`PATH`**
+
+:   Must include `docker`, `python3`, and — if `--upload` is passed —
+    `gh`.
+
+The build script does not itself consume any other environment variables.
+Inside the Docker container, it sets and relies on `PATH`,
+`DEPOT_TOOLS_UPDATE=0`, and (for `musl`) the musl-cross-make toolchain
+prefix.
+
+## EXIT STATUS
+
+| Code | Meaning |
+| --- | --- |
+| `0` | All requested builds completed and, if `--upload` was passed, the release was created. |
+| `1` | A dependency check failed, a Docker build failed, or the `gh release create` call failed. |
+| `130` | Interrupted (SIGINT / Ctrl-C). |
+
+## EXAMPLES
+
+### Build the full default matrix
+
+```bash
+python3 pdfium/build_pdfium.py 7725
+```
+
+Produces `pdfium-linux-x64.tgz`, `pdfium-linux-arm64.tgz`,
+`pdfium-musl-x64.tgz`, `pdfium-musl-arm64.tgz` in `./bin/`.
+
+### Build only musl variants
+
+```bash
+python3 pdfium/build_pdfium.py 7725 --platform musl
+```
+
+### Build one combo for iterative debugging
+
+```bash
+python3 pdfium/build_pdfium.py 7725 --platform musl --arch arm64
+```
+
+### Parallel builds
+
+```bash
+python3 pdfium/build_pdfium.py 7725 --parallel
+```
+
+Runs amd64 and arm64 concurrently within each platform pass. In the
+terminal, press `Tab` / `1` / `2` to switch between each architecture's
+live output.
+
+### Build and publish a release
+
+```bash
+python3 pdfium/build_pdfium.py 7725 --upload
+```
+
+Equivalent to a full build followed by `gh release create pdfium-7725`
+with all four archives attached. The existing release (if any) is
+replaced in place.
+
+### Run via GitHub Actions
+
+Trigger the **Build PDFium** workflow (`.github/workflows/build.yml`) via
+`workflow_dispatch`, supplying the chromium branch number. Tick
+`upload=true` to have the workflow create/replace the GitHub Release
+with all archives from the matrix.
+
+## ARTIFACT LAYOUT
+
+Each `.tgz` extracts to a self-contained directory:
+
+```
+pdfium-<platform>-<gn_cpu>/
+├── lib/
+│   ├── libpdfium.so       # or libpdfium.dylib on mac
+│   └── libpdfium.a        # static archive (not present on mac yet)
+├── include/               # public C headers
+├── args.gn                # GN args used for the shared build
+├── args.static.gn         # GN args used for the static build
+└── LICENSE                # PDFium's BSD-3-Clause license
+```
+
+`args.gn` and `args.static.gn` are kept separate so a consumer
+investigating linker issues can see exactly which flags produced each
+binary. They differ only in the `BUILD.gn` target type that the
+matching patch mode selects.
+
+## CONSUMING THE ARTIFACTS
+
+### Shared library (default for `pdfium-render`)
+
+```bash
+sudo cp pdfium-<plat>-<cpu>/lib/libpdfium.so /usr/local/lib/
+sudo ldconfig
+```
+
+`pdfium-render`'s default `dlopen`-based path resolves the library via
+the system loader, so placing it on `LD_LIBRARY_PATH` or in
+`/usr/local/lib` is sufficient. In Rust:
+
+```rust
+Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./"))
+    .or_else(|_| Pdfium::bind_to_system_library())
+```
+
+### Static archive (for `pdfium-render/static`)
+
+```bash
+export PDFIUM_STATIC_LIB_PATH=/path/to/pdfium-<plat>-<cpu>/lib
+cargo build --features pdfium-render/static
+```
+
+`pdfium-render`'s `static` feature links `libpdfium.a` at build time via
+its `build.rs`, eliminating the `dlopen` step entirely. This is the
+correct choice when the consuming binary is built for a fully-static
+musl target (e.g. `x86_64-unknown-linux-musl` without
+`target-feature=-crt-static`), since `dlopen` is unavailable in such
+binaries.
+
+### Libc compatibility matrix
+
+| Binary libc | Needs `libpdfium.*` from | Notes |
+| --- | --- | --- |
+| glibc (Debian, Ubuntu, …) | `pdfium-linux-*` | |
+| musl (Alpine, distroless musl) | `pdfium-musl-*` | Loading a glibc `.so` from a musl process fails at `dlopen` |
+| macOS | `pdfium-mac-*` (not in default matrix) | Use `--platform mac` to build |
+
+## TROUBLESHOOTING
+
+### `DlOpen { desc: "Dynamic loading not supported" }` from `pdfium-render`
+
+Your Rust binary is built as a fully static musl executable
+(`-C target-feature=+crt-static`), which has no dynamic linker mapped
+in and therefore cannot `dlopen`. Two fixes:
+
+1. **Preferred**: switch to `pdfium-render`'s `static` feature and
+   point `PDFIUM_STATIC_LIB_PATH` at the directory containing
+   `libpdfium.a` from the matching `pdfium-musl-<cpu>.tgz`.
+2. **Alternative**: build your Rust binary with
+   `-C target-feature=-crt-static` so it is a dynamic musl executable,
+   then use the matching `libpdfium.so` from `pdfium-musl-<cpu>.tgz`.
+
+### `libpdfium.so: Error loading shared library: No such file or directory`
+
+The `.so` is not on the loader's search path. Copy it to
+`/usr/local/lib` and run `ldconfig`, or set `LD_LIBRARY_PATH` to the
+directory containing it.
+
+### `undefined reference to FPDF_*` when static-linking
+
+You are using `libpdfium.a` from an older release that predates the
+`FPDF_EXPORT` visibility patch. Upgrade to `pdfium-7725` or newer. The
+visibility patch is applied unconditionally under `--mode base`.
+
+### Docker buildkit steps fail with "no space left on device"
+
+A full default matrix build produces ~30 GB of Docker image layers
+before cleanup. Ensure the Docker daemon has at least that much free
+space, or run `docker system prune` between builds.
+
+## SEE ALSO
+
+- [`pdfium/README.md`](pdfium/README.md) — build pipeline overview and download links
+- [`README.md`](README.md) — repo top-level
+- [`.github/workflows/build.yml`](.github/workflows/build.yml) — CI workflow definition
+- [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — lint + test workflow
+- [bblanchon/pdfium-binaries](https://github.com/bblanchon/pdfium-binaries) — upstream reference build scripts
+- [pdfium-render (Rust)](https://github.com/ajrcarey/pdfium-render) — consumer of the shared/static libraries
+- [PDFium source](https://pdfium.googlesource.com/pdfium/) — upstream project
+
+## HISTORY
+
+- **pdfium-7725** (2026-04) — first release to ship both `libpdfium.so` and `libpdfium.a` per archive, and to include musl-linked variants (`pdfium-musl-x64.tgz`, `pdfium-musl-arm64.tgz`) in the default matrix.
+- **pdfium earlier** — glibc-only shared library releases.
+
+## LICENSE
+
+The build tooling is released under [MIT](LICENSE). PDFium itself is
+released under BSD-3-Clause; the bundled `LICENSE` file inside each
+archive is PDFium's, not this repo's.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,41 @@
 
 Pre-compiled native dependencies for [libviprs](https://github.com/libviprs/libviprs). Each dependency has its own directory with build scripts and documentation. Compiled binaries are published as GitHub Releases.
 
+For a full man-page-style reference on the build tooling, see [`MANUAL.md`](MANUAL.md).
+
 ## Dependencies
 
 | Directory | Library | Purpose |
 | --- | --- | --- |
 | [`pdfium/`](pdfium/) | [PDFium](https://pdfium.googlesource.com/pdfium/) | PDF page rasterization |
+
+## Release contents
+
+Every archive published under [Releases](https://github.com/libviprs/libviprs-dep/releases) ships both a shared library and a static archive so downstream consumers can pick either linking strategy:
+
+```
+pdfium-<platform>-<cpu>/
+├── lib/libpdfium.so   # or .dylib on mac — for dlopen / dynamic linking
+├── lib/libpdfium.a    # static archive for pdfium-render/static
+├── include/           # public C headers
+├── args.gn            # GN args used for the shared build
+├── args.static.gn     # GN args used for the static build
+└── LICENSE
+```
+
+The default release matrix is `{linux, musl} × {amd64, arm64}` — four archives per tag. Pick the `linux-*` archives for glibc runtimes (Debian, Ubuntu, …) and the `musl-*` archives for musl runtimes (Alpine, musl-based distroless images). Loading a glibc `.so` from a musl process — or vice versa — fails at `dlopen` time. macOS (`pdfium-mac-*`) is available on request but not in the default matrix.
+
+See [`pdfium/README.md`](pdfium/README.md#download) for direct download URLs and consumption examples.
+
+## Quickstart
+
+Build the full default matrix for chromium branch 7725 and publish it as a release:
+
+```bash
+python3 pdfium/build_pdfium.py 7725 --parallel --upload
+```
+
+Or trigger the **Build PDFium** GitHub Actions workflow via `workflow_dispatch`, entering the chromium branch number and toggling `upload=true`.
 
 ## Development
 
@@ -44,7 +74,12 @@ GitHub Actions runs on every push and PR to `main`:
 - **test** — pytest on Python 3.9 and 3.12
 - **shellcheck** — validates platform patch scripts
 
-A separate **Build PDFium** workflow is available via manual dispatch for full Docker builds.
+A separate **Build PDFium** workflow (`.github/workflows/build.yml`) is available via manual dispatch. It builds the full `{linux, musl} × {amd64, arm64}` matrix inside Docker and — when `upload=true` is set — creates or replaces the GitHub Release on this repo.
+
+## Further reading
+
+- [`MANUAL.md`](MANUAL.md) — complete man-page-style reference for the build tooling, CLI options, artifact layout, environment, exit statuses, troubleshooting.
+- [`pdfium/README.md`](pdfium/README.md) — PDFium-specific build pipeline overview, GN args, patches.
 
 ## License
 

--- a/pdfium/README.md
+++ b/pdfium/README.md
@@ -1,22 +1,33 @@
 # PDFium
 
-Pre-compiled PDFium shared libraries for [libviprs](https://github.com/libviprs/libviprs). Built from source and published as GitHub Releases on this repo.
+Pre-compiled PDFium libraries for [libviprs](https://github.com/libviprs/libviprs). Built from source and published as GitHub Releases on this repo.
 
 [PDFium](https://pdfium.googlesource.com/pdfium/) is Google's open-source PDF rendering library, used by libviprs to rasterize PDF pages into pixel buffers for tile pyramid generation.
 
 We compile PDFium from source rather than using third-party prebuilt binaries to:
 - Pin to a specific chromium branch for reproducibility
 - Ensure the binary includes all symbols required by the `pdfium-render` Rust bindings
-- Control build configuration (no V8, no XFA, shared library output)
+- Control build configuration (no V8, no XFA)
+- Ship both a shared library and a static archive so downstream crates can pick either linking strategy
+- Ship both glibc and musl builds so downstream consumers are not forced onto a particular libc
 
 ## Download
 
-Archives are available from [Releases](https://github.com/libviprs/libviprs-dep/releases):
+Archives are available from [Releases](https://github.com/libviprs/libviprs-dep/releases). Each release tag bundles four archives covering the full matrix of `{linux, musl}` × `{x64, arm64}`:
 
 ```
 https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-x64.tgz
 https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-arm64.tgz
+https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-musl-x64.tgz
+https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-musl-arm64.tgz
 ```
+
+| Archive suffix | libc | Compatible runtime |
+| --- | --- | --- |
+| `linux-x64`, `linux-arm64` | glibc | Debian, Ubuntu, RHEL, most mainstream distros |
+| `musl-x64`, `musl-arm64`   | musl  | Alpine, any container built `FROM alpine:*`, musl-based distroless images |
+
+Pick the archive whose libc matches the runtime that will load PDFium. Loading a glibc `.so` from a musl process (or vice versa) fails at `dlopen` time with opaque errors — the libc mismatch is the single most common source of "pdfium doesn't load in my container" tickets.
 
 Each archive extracts to a self-contained directory:
 
@@ -27,59 +38,82 @@ tar xzf pdfium-linux-x64.tgz
 ```
 pdfium-linux-x64/
   lib/
-    libpdfium.so
+    libpdfium.so       # shared library, for dlopen and dynamic linking
+    libpdfium.a        # static archive, for pdfium-render/static or equivalent
   include/
     fpdfview.h
     fpdf_annot.h
     ...
-  args.gn
+  args.gn              # GN args used for the shared-library build
+  args.static.gn       # GN args used for the static-archive build
   LICENSE
 ```
 
-To install the shared library:
+### Installing the shared library
 
 ```bash
 sudo cp pdfium-linux-x64/lib/libpdfium.so /usr/local/lib/
 sudo ldconfig
 ```
 
+### Using the static archive
+
+`pdfium-render`'s `static` feature expects `libpdfium.a` to be discoverable via `PDFIUM_STATIC_LIB_PATH`:
+
+```bash
+export PDFIUM_STATIC_LIB_PATH=/path/to/pdfium-linux-x64/lib
+cargo build --features pdfium-render/static
+```
+
+See the [pdfium-render documentation](https://docs.rs/pdfium-render/) for the full list of feature flags.
+
 ## Building from source
 
-The `build_pdfium.py` script compiles PDFium inside Docker containers. All builds run on an amd64 host — arm64 binaries are cross-compiled using PDFium's built-in clang and Debian sysroot, avoiding slow QEMU emulation.
+The `build_pdfium.py` script compiles PDFium inside Docker containers and produces both a `.so` and a `.a` per platform × architecture. By default it builds the full linux + musl matrix. All builds run on an amd64 host — arm64 binaries are cross-compiled, avoiding slow QEMU emulation.
 
 The build pipeline (inspired by [bblanchon/pdfium-binaries](https://github.com/bblanchon/pdfium-binaries)):
 
 1. Install system dependencies and depot_tools
 2. Configure gclient with `checkout_configuration=small` (skips V8, test deps, cipd)
 3. Checkout PDFium source at the target chromium branch
-4. Install build dependencies and target architecture sysroot
-5. Apply platform patch from `patches/<platform>.py`
-6. Configure GN args and generate build files
-7. Build with ninja
-8. Verify output binary
-9. Stage artifacts (`lib/`, `include/`, `args.gn`, `LICENSE`) and package as `pdfium-{platform}-{gn_cpu}.tgz`
+4. Install build dependencies and target architecture sysroot (linux) or musl-cross-make toolchain (musl)
+5. Apply the **base** platform patch — symbol visibility, musl toolchain GN config where relevant. Leaves `BUILD.gn` alone so `component("pdfium")` resolves to `static_library` under `is_component_build=false`.
+6. `gn gen out/Static` + `ninja -C out/Static pdfium` — produces `libpdfium.a`
+7. Apply the **shared** platform patch — rewrites `component("pdfium")` to `shared_library("pdfium")`.
+8. `gn gen out/Shared` + `ninja -C out/Shared pdfium` — produces `libpdfium.so`
+9. Verify both outputs
+10. Stage artifacts into a single directory and package as `pdfium-{platform}-{gn_cpu}.tgz`
+
+The two-phase ninja build is the cleanest way to emit both a static archive and a shared library from a single source checkout without duplicating the `component("pdfium")` target body inside `BUILD.gn`. It roughly doubles the ninja time per combo, but the expensive Docker setup steps (apt, depot_tools, gclient sync, runhooks) only run once per combo.
 
 ### Requirements
 
-- Docker
+- Docker with buildx support
 - Python 3.7+
 - `gh` CLI (only for `--upload`)
 
 ### Usage
 
 ```bash
-# Build both architectures for a specific chromium branch
+# Build the full default matrix (linux + musl, amd64 + arm64 — four archives)
 python3 build_pdfium.py 7725
 
-# Build both architectures in parallel
-python3 build_pdfium.py 7725 --parallel
-
-# Build a single architecture
-python3 build_pdfium.py 7725 --arch amd64
-python3 build_pdfium.py 7725 --arch arm64
-
-# Explicit platform (default: linux)
+# Build a single platform
 python3 build_pdfium.py 7725 --platform linux
+python3 build_pdfium.py 7725 --platform musl
+python3 build_pdfium.py 7725 --platform mac
+
+# Build multiple specific platforms
+python3 build_pdfium.py 7725 --platform linux musl
+
+# Build a single architecture across all default platforms
+python3 build_pdfium.py 7725 --arch amd64
+
+# Combine: single platform, single arch
+python3 build_pdfium.py 7725 --platform musl --arch arm64
+
+# Build archs in parallel (within each platform pass)
+python3 build_pdfium.py 7725 --parallel
 
 # Build and upload to GitHub Releases
 python3 build_pdfium.py 7725 --upload
@@ -103,12 +137,14 @@ Branch numbers increase over time. Higher numbers correspond to newer chromium r
 
 ### Output
 
-Archives are written to `./bin/` by default (gitignored):
+Archives are written to `./bin/` by default (gitignored). With the default platform set, a full run produces:
 
 ```
 bin/
   pdfium-linux-x64.tgz
   pdfium-linux-arm64.tgz
+  pdfium-musl-x64.tgz
+  pdfium-musl-arm64.tgz
 ```
 
 Archives follow the naming convention `pdfium-{platform}-{gn_cpu}.tgz` and extract to a directory of the same name:
@@ -116,22 +152,24 @@ Archives follow the naming convention `pdfium-{platform}-{gn_cpu}.tgz` and extra
 ```
 pdfium-{platform}-{gn_cpu}/
   lib/libpdfium.so       # shared library
+  lib/libpdfium.a        # static archive
   include/*.h            # public C headers
-  args.gn                # GN build arguments used
+  args.gn                # GN build arguments for the shared build
+  args.static.gn         # GN build arguments for the static build
   LICENSE                # PDFium license
 ```
 
-When `--upload` is used, a GitHub Release tagged `pdfium-{version}` is created with the archives attached.
+When `--upload` is used, a GitHub Release tagged `pdfium-{version}` is created with all archives attached.
 
 ### Parallel builds
 
-By default, architectures are built sequentially. Use `--parallel` to build all targets at the same time:
+By default, architectures within a platform are built sequentially. Use `--parallel` to build all architectures of a platform simultaneously:
 
 ```bash
 python3 build_pdfium.py 7725 --parallel
 ```
 
-Both Docker builds run concurrently in separate threads. The terminal progress header tracks both architectures independently.
+Platform passes still run sequentially (so the full default invocation builds linux first, then musl), but within each platform pass the amd64 and arm64 Docker builds run concurrently in separate threads.
 
 During a parallel build, you can switch between each architecture's build output:
 
@@ -147,18 +185,22 @@ The active view is shown in the header bar. Each architecture's output is buffer
 
 ### Build time
 
-PDFium is a large C++ project. Expect:
-- ~10-20 minutes per architecture
-- `--parallel` can cut total wall time roughly in half when building both architectures
+PDFium is a large C++ project. With the two-phase build, expect:
+- ~20–40 minutes per architecture per platform (roughly double the single-phase time)
+- `--parallel` can cut wall time roughly in half when building both architectures of the same platform
+
+A full default matrix build on a fast machine takes 60–90 minutes wall time with `--parallel` enabled.
 
 ### Cross-compilation
 
-arm64 binaries are cross-compiled inside an amd64 Docker container. This works by:
+**linux** — arm64 binaries are cross-compiled inside an amd64 Docker container. This works by:
 - Installing `g++-aarch64-linux-gnu` for the cross-compiler toolchain
 - Running `install-sysroot.py --arch=arm64` to install a Debian arm64 sysroot
 - Setting `target_cpu = "arm64"` in GN args
 
 PDFium's build system uses its own bundled clang with the sysroot, producing a native arm64 `.so` without needing QEMU.
+
+**musl** — both x86_64 and aarch64 musl builds use the [musl-cross-make](https://musl.cc) toolchains downloaded at build time (`x86_64-linux-musl-cross.tgz`, `aarch64-linux-musl-cross.tgz`). A custom GN toolchain definition is installed at `build/toolchain/linux/musl/BUILD.gn` that routes compilation through the prefixed GCC toolchain. `BUILDCONFIG.gn` is patched to declare an `is_musl` arg and select the musl toolchain when it is set.
 
 ## Build configuration
 
@@ -170,33 +212,46 @@ PDFium is compiled with these GN arguments:
 | `pdf_is_standalone` | `true` | No chromium browser integration |
 | `pdf_enable_v8` | `false` | No JavaScript engine needed |
 | `pdf_enable_xfa` | `false` | No XFA form support needed |
-| `is_component_build` | `false` | Single self-contained `.so` |
-| `use_custom_libcxx` | `true` | Bundle libc++ so the `.so` is portable across distros |
+| `is_component_build` | `false` | Single self-contained library per target |
+| `use_custom_libcxx` | `true` (linux) / `false` (musl) | Bundle libc++ on glibc to stay portable; rely on musl-cross-make's libstdc++ on musl |
 | `treat_warnings_as_errors` | `false` | Avoid build failures from upstream warnings |
 | `pdf_use_skia` | `false` | Use default rendering backend |
 | `pdf_use_partition_alloc` | `false` | Skip complex allocator that fails on some platforms |
 | `clang_use_chrome_plugins` | `false` | Skip Chrome's custom clang plugins |
 | `target_cpu` | `"x64"` / `"arm64"` | Target architecture |
 | `target_os` | `"linux"` | Target operating system |
+| `is_musl` | `true` (musl only) | Select the musl toolchain routing in BUILDCONFIG.gn |
 
 ### Platform patches
 
-Platform-specific patches live in `patches/<platform>.py`. The `--platform` flag selects which patch script to apply during the build (default: `linux`). Each patch script receives the PDFium source directory as its first argument.
+Platform-specific patches live in `patches/<platform>.py`. The `--platform` flag selects which patch script to apply during the build. Each patch script accepts a `--mode` flag (`base` / `shared` / `all`) so the build orchestrator can apply only the symbol-visibility patches before the static build and then layer the BUILD.gn shared-library rewrite on top before the second ninja pass.
 
 ```
 patches/
-  linux.py     # Linux shared library patches
+  linux.py     # glibc linux shared library patches
+  mac.py       # macOS shared library patches (single-phase today)
+  musl.py      # musl/Alpine patches + toolchain install
 ```
 
-The Linux patch applies two changes required to produce a `.so` with exported `FPDF_*` symbols:
+Each `patches/<name>.py` script takes the PDFium source directory as its positional argument and an optional `--mode` flag:
 
-1. **BUILD.gn** — changes `component("pdfium")` to `shared_library("pdfium")`. The `component()` macro resolves to `static_library` when `is_component_build=false`, so without this patch the output would be a `.a` archive instead of a `.so`.
+| Mode | Effect |
+| --- | --- |
+| `base` | Everything needed for the static-archive build: `fpdfview.h` visibility patch, plus musl's BUILDCONFIG / highway / toolchain install where applicable |
+| `shared` | Rewrites `component("pdfium")` → `shared_library("pdfium")` in `BUILD.gn`, applied after the static ninja pass |
+| `all` | Both `base` and `shared` (default — equivalent to running `base` then `shared`) |
 
-2. **fpdfview.h** — removes the `#if defined(COMPONENT_BUILD)` guard around `FPDF_EXPORT`. PDFium only applies `__attribute__((visibility("default")))` to its public API when `COMPONENT_BUILD` is defined. Since we set `is_component_build=false` (to get a single `.so` instead of many small ones), `FPDF_EXPORT` resolves to nothing without this patch, and all `FPDF_*` symbols get hidden visibility — making the library unusable via `dlopen`/`dlsym`.
+The Linux patches apply two changes required to produce a `.so` with exported `FPDF_*` symbols:
+
+1. **BUILD.gn** — changes `component("pdfium")` to `shared_library("pdfium")`. The `component()` macro resolves to `static_library` when `is_component_build=false`, so without this patch the output would be a `.a` archive instead of a `.so`. We exploit this deliberately to get the static archive first, then apply the patch and run ninja a second time to get the shared library.
+
+2. **fpdfview.h** — removes the `#if defined(COMPONENT_BUILD)` guard around `FPDF_EXPORT`. PDFium only applies `__attribute__((visibility("default")))` to its public API when `COMPONENT_BUILD` is defined. Since we set `is_component_build=false` (to get a single `.so` instead of many small ones), `FPDF_EXPORT` resolves to nothing without this patch, and all `FPDF_*` symbols get hidden visibility — making the library unusable via `dlopen`/`dlsym` and unusable when linked statically into a Rust binary that relies on the exported C ABI.
 
 These patches match the approach used by [bblanchon/pdfium-binaries](https://github.com/bblanchon/pdfium-binaries) (`shared_library.patch` + `public_headers.patch`).
 
-To add a new platform, create a `patches/<name>.py` script and add the name to the `PLATFORMS` list in `build_pdfium.py`.
+The musl patches add three more changes on top: declare an `is_musl` GN arg and route the default toolchain to the musl one in `BUILDCONFIG.gn`, disable `HWY_AVX3_SPR` in `third_party/highway/BUILD.gn` (highway emits broken SIMD on musl x86 otherwise), and install the musl GN toolchain definition at `build/toolchain/linux/musl/BUILD.gn`. All of these are part of `--mode base` and run before the static build.
+
+To add a new platform, create a `patches/<name>.py` script that accepts `--mode base|shared|all`, and add the name to the `PLATFORMS` list in `build_pdfium.py`.
 
 ## Testing
 
@@ -212,7 +267,11 @@ Tests cover:
 | File | What it tests |
 | --- | --- |
 | `test_formatting.py` | `fmt_time`, `make_bar` output |
-| `test_naming.py` | Archive and directory naming convention |
+| `test_naming.py` | Archive and directory naming convention across linux/musl and amd64/arm64 |
 | `test_step_regex.py` | Docker buildkit and ninja step marker parsing |
-| `test_dockerfile.py` | Generated Dockerfile content for amd64 and arm64 |
+| `test_dockerfile.py` | Generated Dockerfile content for linux amd64/arm64 and musl amd64/arm64, including the two-phase build structure |
 | `test_eta.py` | EMA-based ETA estimation lifecycle |
+
+## Reference
+
+See [`MANUAL.md`](../MANUAL.md) at the repo root for a full man-page-style reference on the build tooling.

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -638,7 +638,13 @@ def make_dockerfile(version, arch, plat):
 
 
 def _make_dockerfile_linux(version, arch, plat):
-    """Dockerfile for Linux builds (runs in Docker, cross-compiles arm64)."""
+    """Dockerfile for Linux builds (runs in Docker, cross-compiles arm64).
+
+    Two ninja phases are run against the same source checkout so the
+    release archive ships both ``libpdfium.a`` (produced by the
+    base-patched ``component("pdfium")`` → ``static_library``) and
+    ``libpdfium.so`` (produced after the shared-library rewrite).
+    """
     target = TARGETS[arch]
     gn_cpu = target["gn_cpu"]
     branch = f"chromium/{version}"
@@ -685,26 +691,40 @@ RUN build/install-build-deps.sh --no-prompt --no-chromeos-fonts --no-nacl || tru
 RUN gclient runhooks
 RUN python3 build/linux/sysroot_scripts/install-sysroot.py --arch={gn_cpu}
 
-# Step 5: Apply platform patch
+# Step 5: Apply base platform patch (fpdfview.h symbol visibility only)
 COPY platform.py /tmp/platform.py
-RUN python3 /tmp/platform.py /build/pdfium
+RUN python3 /tmp/platform.py /build/pdfium --mode base
 
-# Step 6: Configure GN
-RUN mkdir -p out/Release && cat > out/Release/args.gn <<'ARGS'
+# Step 6: Configure static build
+RUN mkdir -p out/Static && cat > out/Static/args.gn <<'ARGS'
 {gn_args}ARGS
-RUN gn gen out/Release
+RUN gn gen out/Static
 
-# Step 7: Build
-RUN ninja -C out/Release pdfium
+# Step 7: Build static archive (component() -> static_library -> libpdfium.a)
+RUN ninja -C out/Static pdfium
 
-# Step 8: Verify output
-RUN ls -lh out/Release/libpdfium.so && file out/Release/libpdfium.so
+# Step 8: Apply shared-library patch on top of base
+RUN python3 /tmp/platform.py /build/pdfium --mode shared
 
-# Step 9: Stage artifacts into /staging
+# Step 9: Configure shared build
+RUN mkdir -p out/Shared && cat > out/Shared/args.gn <<'ARGS'
+{gn_args}ARGS
+RUN gn gen out/Shared
+
+# Step 10: Build shared library (shared_library -> libpdfium.so)
+RUN ninja -C out/Shared pdfium
+
+# Step 11: Verify both outputs
+RUN ls -lh out/Static/libpdfium.a out/Shared/libpdfium.so && \\
+    file out/Static/libpdfium.a out/Shared/libpdfium.so
+
+# Step 12: Stage artifacts into /staging
 COPY LICENSE /tmp/LICENSE
 RUN mkdir -p /staging/lib /staging/include && \\
-    cp out/Release/libpdfium.so /staging/lib/ && \\
-    cp out/Release/args.gn /staging/ && \\
+    cp out/Shared/libpdfium.so /staging/lib/ && \\
+    cp out/Static/libpdfium.a /staging/lib/ && \\
+    cp out/Shared/args.gn /staging/args.gn && \\
+    cp out/Static/args.gn /staging/args.static.gn && \\
     cp -r public/*.h /staging/include/ && \\
     cp /tmp/LICENSE /staging/
 """
@@ -780,9 +800,11 @@ RUN mkdir -p /staging/lib /staging/include && \\
 def _make_dockerfile_musl(version, arch):
     """Dockerfile for musl (Alpine-compatible) builds.
 
-    Uses musl-cross-make toolchains instead of Chromium's clang.
-    The musl patch script installs a custom GN toolchain definition
-    and patches BUILDCONFIG.gn to route builds through musl-gcc.
+    Uses musl-cross-make toolchains instead of Chromium's clang. The
+    musl patch script installs a custom GN toolchain definition and
+    patches BUILDCONFIG.gn to route builds through musl-gcc. Like the
+    linux dockerfile, this runs two ninja phases so a single source
+    checkout produces both ``libpdfium.a`` and ``libpdfium.so``.
     """
     target = TARGETS[arch]
     gn_cpu = target["gn_cpu"]
@@ -830,26 +852,40 @@ RUN gclient sync -r "origin/{branch}" --no-history --shallow
 WORKDIR /build/pdfium
 RUN gclient runhooks
 
-# Step 6: Apply platform patch
+# Step 6: Apply base platform patch (no shared_library rewrite yet)
 COPY platform.py /tmp/platform.py
-RUN python3 /tmp/platform.py /build/pdfium
+RUN python3 /tmp/platform.py /build/pdfium --mode base
 
-# Step 7: Configure GN
-RUN mkdir -p out/Release && cat > out/Release/args.gn <<'ARGS'
+# Step 7: Configure static build
+RUN mkdir -p out/Static && cat > out/Static/args.gn <<'ARGS'
 {gn_args}ARGS
-RUN gn gen out/Release
+RUN gn gen out/Static
 
-# Step 8: Build
-RUN ninja -C out/Release pdfium
+# Step 8: Build static archive (component() -> static_library -> libpdfium.a)
+RUN ninja -C out/Static pdfium
 
-# Step 9: Verify output
-RUN ls -lh out/Release/libpdfium.so && file out/Release/libpdfium.so
+# Step 9: Apply shared-library patch on top of base
+RUN python3 /tmp/platform.py /build/pdfium --mode shared
 
-# Step 10: Stage artifacts into /staging
+# Step 10: Configure shared build
+RUN mkdir -p out/Shared && cat > out/Shared/args.gn <<'ARGS'
+{gn_args}ARGS
+RUN gn gen out/Shared
+
+# Step 11: Build shared library (shared_library -> libpdfium.so)
+RUN ninja -C out/Shared pdfium
+
+# Step 12: Verify both outputs
+RUN ls -lh out/Static/libpdfium.a out/Shared/libpdfium.so && \\
+    file out/Static/libpdfium.a out/Shared/libpdfium.so
+
+# Step 13: Stage artifacts into /staging
 COPY LICENSE /tmp/LICENSE
 RUN mkdir -p /staging/lib /staging/include && \\
-    cp out/Release/libpdfium.so /staging/lib/ && \\
-    cp out/Release/args.gn /staging/ && \\
+    cp out/Shared/libpdfium.so /staging/lib/ && \\
+    cp out/Static/libpdfium.a /staging/lib/ && \\
+    cp out/Shared/args.gn /staging/args.gn && \\
+    cp out/Static/args.gn /staging/args.static.gn && \\
     cp -r public/*.h /staging/include/ && \\
     cp /tmp/LICENSE /staging/
 """
@@ -1060,8 +1096,14 @@ def main():
     parser.add_argument(
         "--platform",
         choices=PLATFORMS,
-        default="linux",
-        help="target platform — selects the patch script from patches/ (default: linux)",
+        nargs="+",
+        default=None,
+        help=(
+            "target platform(s) — selects patch script(s) from patches/. "
+            "Accepts multiple values (e.g. --platform linux musl). "
+            "Default: linux + musl, so each release ships both a glibc and "
+            "a musl variant. Pass --platform mac to build macOS alone."
+        ),
     )
     parser.add_argument(
         "--parallel",
@@ -1083,49 +1125,60 @@ def main():
     check_dependencies(upload=args.upload)
 
     archs = [args.arch] if args.arch else ["amd64", "arm64"]
+    platforms = args.platform if args.platform else ["linux", "musl"]
     output_dir = os.path.abspath(args.output_dir)
     os.makedirs(output_dir, exist_ok=True)
 
-    progress = BuildProgress(args.version, archs, parallel=args.parallel)
-
     built_files = []
     try:
-        plat = args.platform
-        if args.parallel and len(archs) > 1:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=len(archs)) as pool:
-                futures = {
-                    pool.submit(
-                        build_for_arch,
-                        args.version,
-                        arch,
-                        plat,
-                        output_dir,
-                        progress,
-                    ): arch
-                    for arch in archs
-                }
-                for future in concurrent.futures.as_completed(futures):
-                    arch = futures[future]
-                    built_files.append(future.result())
-            # Sort so upload order is deterministic (amd64 before arm64)
-            built_files.sort()
-        else:
-            for arch in archs:
-                path = build_for_arch(args.version, arch, plat, output_dir, progress)
-                built_files.append(path)
+        # Each platform pass gets its own BuildProgress so per-arch status
+        # lines stay readable. Parallelism is within a platform (archs
+        # fan out in parallel); platforms run sequentially so the terminal
+        # UI doesn't have to juggle more than two or three rows at once.
+        for plat in platforms:
+            print(f"\n{'=' * 60}\n  Platform: {plat}\n{'=' * 60}\n", flush=True)
+            progress = BuildProgress(args.version, archs, parallel=args.parallel)
+            try:
+                if args.parallel and len(archs) > 1:
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=len(archs)) as pool:
+                        futures = {
+                            pool.submit(
+                                build_for_arch,
+                                args.version,
+                                arch,
+                                plat,
+                                output_dir,
+                                progress,
+                            ): arch
+                            for arch in archs
+                        }
+                        for future in concurrent.futures.as_completed(futures):
+                            built_files.append(future.result())
+                else:
+                    for arch in archs:
+                        path = build_for_arch(args.version, arch, plat, output_dir, progress)
+                        built_files.append(path)
+            finally:
+                progress.finish()
+
+        # Sort so upload order is deterministic regardless of parallel completion order.
+        built_files.sort()
 
         if args.upload:
-            upload_release(args.version, built_files, progress)
+            # Reuse a lightweight progress instance just to show the "Uploading..."
+            # banner during the gh release create; no arch work runs here.
+            upload_progress = BuildProgress(args.version, archs, parallel=False)
+            try:
+                upload_release(args.version, built_files, upload_progress)
+            finally:
+                upload_progress.finish()
     except (RuntimeError, subprocess.CalledProcessError) as e:
-        progress.finish()
         print(f"\nError: {e}", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
-        progress.finish()
         print("\nInterrupted.", file=sys.stderr)
         sys.exit(130)
 
-    progress.finish()
     print(f"\nBuilt {len(built_files)} binaries in {output_dir}/")
 
 

--- a/pdfium/patches/linux.py
+++ b/pdfium/patches/linux.py
@@ -1,30 +1,34 @@
 #!/usr/bin/env python3
-"""Platform patch for Linux shared library builds.
+"""Platform patch for Linux PDFium builds.
 
-Two changes are required to produce a .so with exported FPDF_* symbols:
+The patch is split into two modes so a single source checkout can
+produce *both* a static archive and a shared library:
 
-1. Change component("pdfium") to shared_library("pdfium") in BUILD.gn.
-   The component() macro resolves to static_library when
-   is_component_build=false, so without this the output would be a .a
-   archive instead of a .so.
+* ``base`` — applied once before any build. Only modifies
+  ``public/fpdfview.h`` to strip the ``COMPONENT_BUILD`` guard around
+  ``FPDF_EXPORT``, ensuring the public C API symbols always have
+  ``visibility("default")``. Leaves ``BUILD.gn`` alone, so the
+  ``component("pdfium")`` target resolves to ``static_library`` under
+  ``is_component_build=false`` and a subsequent ninja build produces
+  ``libpdfium.a``.
 
-2. Remove the COMPONENT_BUILD guard around FPDF_EXPORT in fpdfview.h.
-   PDFium only defines FPDF_EXPORT (which applies
-   __attribute__((visibility("default")))) when COMPONENT_BUILD is defined.
-   Since we set is_component_build=false (to get a single .so instead of
-   many small ones), FPDF_EXPORT resolves to nothing and all FPDF_*
-   symbols get default-hidden visibility.
-   Removing the guard ensures FPDF_EXPORT always applies
-   visibility("default"), making the public C API accessible via
-   dlopen/dlsym.
+* ``shared`` — applied on top of ``base`` before the second ninja pass.
+  Rewrites ``component("pdfium")`` to ``shared_library("pdfium")`` in
+  ``BUILD.gn`` so the same target now links a ``.so``. Invoking ninja in
+  a separate out dir then yields ``libpdfium.so`` using the already-built
+  object files would be ideal, but GN invalidates the target type change
+  and recompiles — acceptable cost for a single-source build.
 
-These two patches match what bblanchon/pdfium-binaries uses
+Together this gives us both artifacts from one checkout.
+
+These patches match what bblanchon/pdfium-binaries uses
 (shared_library.patch + public_headers.patch).
 
 Usage:
-    python3 linux.py /path/to/pdfium
+    python3 linux.py /path/to/pdfium [--mode base|shared|all]
 """
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -93,17 +97,29 @@ def patch_fpdfview_h(pdfium_dir: Path) -> None:
 
 
 def main() -> None:
-    if len(sys.argv) < 2:
-        pdfium_dir = Path(".")
-    else:
-        pdfium_dir = Path(sys.argv[1])
+    parser = argparse.ArgumentParser(description="Apply PDFium linux patches.")
+    parser.add_argument("pdfium_dir", nargs="?", default=".", help="PDFium source dir")
+    parser.add_argument(
+        "--mode",
+        choices=["base", "shared", "all"],
+        default="all",
+        help=(
+            "base = fpdfview.h only (keeps component() -> static_library, "
+            "produces libpdfium.a); shared = adds the BUILD.gn rewrite "
+            "to produce libpdfium.so; all = both (default, legacy behavior)."
+        ),
+    )
+    args = parser.parse_args()
 
+    pdfium_dir = Path(args.pdfium_dir)
     if not (pdfium_dir / "BUILD.gn").exists():
         print(f"Error: {pdfium_dir}/BUILD.gn not found", file=sys.stderr)
         sys.exit(1)
 
-    patch_build_gn(pdfium_dir)
-    patch_fpdfview_h(pdfium_dir)
+    if args.mode in ("base", "all"):
+        patch_fpdfview_h(pdfium_dir)
+    if args.mode in ("shared", "all"):
+        patch_build_gn(pdfium_dir)
 
 
 if __name__ == "__main__":

--- a/pdfium/patches/mac.py
+++ b/pdfium/patches/mac.py
@@ -21,9 +21,13 @@ Patches 1 and 2 match bblanchon/pdfium-binaries (shared_library.patch +
 public_headers.patch). Patch 3 matches bblanchon's patches/mac/build.patch.
 
 Usage:
-    python3 mac.py /path/to/pdfium
+    python3 mac.py /path/to/pdfium [--mode base|shared|all]
+
+mac builds are single-phase today (only produce .dylib), so base + shared
+are both honored but the default ``all`` matches the legacy behavior.
 """
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -97,18 +101,29 @@ def patch_apple_toolchain(pdfium_dir: Path) -> None:
 
 
 def main() -> None:
-    if len(sys.argv) < 2:
-        pdfium_dir = Path(".")
-    else:
-        pdfium_dir = Path(sys.argv[1])
+    parser = argparse.ArgumentParser(description="Apply PDFium mac patches.")
+    parser.add_argument("pdfium_dir", nargs="?", default=".", help="PDFium source dir")
+    parser.add_argument(
+        "--mode",
+        choices=["base", "shared", "all"],
+        default="all",
+        help=(
+            "base = fpdfview/toolchain only; shared adds the BUILD.gn rewrite; "
+            "all = both (default)."
+        ),
+    )
+    args = parser.parse_args()
 
+    pdfium_dir = Path(args.pdfium_dir)
     if not (pdfium_dir / "BUILD.gn").exists():
         print(f"Error: {pdfium_dir}/BUILD.gn not found", file=sys.stderr)
         sys.exit(1)
 
-    patch_build_gn(pdfium_dir)
-    patch_fpdfview_h(pdfium_dir)
-    patch_apple_toolchain(pdfium_dir)
+    if args.mode in ("base", "all"):
+        patch_fpdfview_h(pdfium_dir)
+        patch_apple_toolchain(pdfium_dir)
+    if args.mode in ("shared", "all"):
+        patch_build_gn(pdfium_dir)
 
 
 if __name__ == "__main__":

--- a/pdfium/patches/musl.py
+++ b/pdfium/patches/musl.py
@@ -1,38 +1,34 @@
 #!/usr/bin/env python3
-"""Platform patch for musl (Alpine) shared library builds.
+"""Platform patch for musl (Alpine) PDFium builds.
 
-Four changes are required on top of the standard Linux patches:
+Mirrors the linux patch's two-mode split so a single checkout yields
+both ``libpdfium.a`` and ``libpdfium.so``:
 
-1. Change component("pdfium") to shared_library("pdfium") in BUILD.gn.
-   Same as Linux — component() resolves to static_library when
-   is_component_build=false.
+* ``base`` — applied before the static-archive build. Does everything
+  *except* the BUILD.gn ``component()`` rewrite:
+    - ``fpdfview.h``: strip COMPONENT_BUILD guard around FPDF_EXPORT.
+    - ``BUILDCONFIG.gn``: declare ``is_musl``, route default toolchain
+      to ``//build/toolchain/linux/musl``, disable ``-fstack-protector``.
+    - ``third_party/highway/BUILD.gn``: disable ``HWY_AVX3_SPR`` on
+      32-bit (otherwise highway emits broken SIMD on musl x86).
+    - Install the musl GN toolchain at
+      ``build/toolchain/linux/musl/BUILD.gn`` (gcc_toolchain entries for
+      x86/x64/arm/arm64 using musl-cross-make prefixes).
+  With these in place, ``component("pdfium")`` still resolves to
+  ``static_library`` under ``is_component_build=false`` and produces
+  ``libpdfium.a``.
 
-2. Remove the COMPONENT_BUILD guard around FPDF_EXPORT in fpdfview.h.
-   Same as Linux — ensures FPDF_EXPORT always applies
-   visibility("default").
-
-3. Patch build/config/BUILDCONFIG.gn to:
-   - Declare the is_musl GN arg.
-   - Route the default toolchain to //build/toolchain/linux/musl when
-     is_musl is true.
-   - Disable -fstack-protector under musl (musl's __stack_chk_fail is
-     incompatible with the flags Chromium passes).
-
-4. Patch third_party/highway/BUILD.gn to also disable HWY_AVX3_SPR on
-   32-bit builds. Without this, highway emits broken SIMD code on musl
-   x86.
-
-5. Install the musl GN toolchain definition at
-   build/toolchain/linux/musl/BUILD.gn. This defines gcc_toolchain()
-   entries for x86, x64, arm, and arm64 using musl-cross-make prefixed
-   compilers.
+* ``shared`` — applied on top of ``base``. Rewrites
+  ``component("pdfium")`` to ``shared_library("pdfium")`` in BUILD.gn
+  so a second ninja pass yields ``libpdfium.so``.
 
 All patches match bblanchon/pdfium-binaries (patches/musl/).
 
 Usage:
-    python3 musl.py /path/to/pdfium
+    python3 musl.py /path/to/pdfium [--mode base|shared|all]
 """
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -245,20 +241,32 @@ gcc_toolchain("arm64") {
 
 
 def main() -> None:
-    if len(sys.argv) < 2:
-        pdfium_dir = Path(".")
-    else:
-        pdfium_dir = Path(sys.argv[1])
+    parser = argparse.ArgumentParser(description="Apply PDFium musl patches.")
+    parser.add_argument("pdfium_dir", nargs="?", default=".", help="PDFium source dir")
+    parser.add_argument(
+        "--mode",
+        choices=["base", "shared", "all"],
+        default="all",
+        help=(
+            "base = everything except BUILD.gn component->shared rewrite "
+            "(produces libpdfium.a); shared = adds the BUILD.gn rewrite "
+            "(produces libpdfium.so); all = both (default, legacy behavior)."
+        ),
+    )
+    args = parser.parse_args()
 
+    pdfium_dir = Path(args.pdfium_dir)
     if not (pdfium_dir / "BUILD.gn").exists():
         print(f"Error: {pdfium_dir}/BUILD.gn not found", file=sys.stderr)
         sys.exit(1)
 
-    patch_build_gn(pdfium_dir)
-    patch_fpdfview_h(pdfium_dir)
-    patch_buildconfig_gn(pdfium_dir)
-    patch_highway_build_gn(pdfium_dir)
-    install_musl_toolchain(pdfium_dir)
+    if args.mode in ("base", "all"):
+        patch_fpdfview_h(pdfium_dir)
+        patch_buildconfig_gn(pdfium_dir)
+        patch_highway_build_gn(pdfium_dir)
+        install_musl_toolchain(pdfium_dir)
+    if args.mode in ("shared", "all"):
+        patch_build_gn(pdfium_dir)
 
 
 if __name__ == "__main__":

--- a/pdfium/tests/test_dockerfile.py
+++ b/pdfium/tests/test_dockerfile.py
@@ -1,9 +1,16 @@
-"""Tests for generated Dockerfile content."""
+"""Tests for generated Dockerfile content.
+
+The build runs in two phases per platform so the release archive ships
+both ``libpdfium.a`` (from the base patch — ``component()`` stays as
+``static_library``) and ``libpdfium.so`` (from the shared-library
+rewrite applied on top). The assertions below lock in that two-phase
+structure for each platform.
+"""
 
 import build_pdfium as bp
 
 
-class TestMakeDockerfileAmd64:
+class TestMakeDockerfileLinuxAmd64:
     def setup_method(self):
         self.df = bp.make_dockerfile("7725", "amd64", "linux")
 
@@ -42,21 +49,43 @@ class TestMakeDockerfileAmd64:
     def test_platform_patch_copied(self):
         assert "COPY platform.py" in self.df
 
-    def test_shared_library_gn_args(self):
+    def test_base_patch_applied_before_static_build(self):
+        base_pos = self.df.index("--mode base")
+        static_ninja_pos = self.df.index("ninja -C out/Static pdfium")
+        assert base_pos < static_ninja_pos
+
+    def test_shared_patch_applied_between_builds(self):
+        static_ninja_pos = self.df.index("ninja -C out/Static pdfium")
+        shared_patch_pos = self.df.index("--mode shared")
+        shared_ninja_pos = self.df.index("ninja -C out/Shared pdfium")
+        assert static_ninja_pos < shared_patch_pos < shared_ninja_pos
+
+    def test_gn_args(self):
         assert "is_component_build = false" in self.df
         assert "pdf_use_partition_alloc = false" in self.df
         assert "clang_use_chrome_plugins = false" in self.df
 
-    def test_staging_step(self):
+    def test_two_ninja_invocations(self):
+        assert "ninja -C out/Static pdfium" in self.df
+        assert "ninja -C out/Shared pdfium" in self.df
+
+    def test_two_gn_gen_invocations(self):
+        assert "gn gen out/Static" in self.df
+        assert "gn gen out/Shared" in self.df
+
+    def test_staging_contains_both_artifacts(self):
         assert "/staging/lib" in self.df
         assert "/staging/include" in self.df
+        assert "libpdfium.so /staging/lib/" in self.df
+        assert "libpdfium.a /staging/lib/" in self.df
         assert "COPY LICENSE" in self.df
 
-    def test_ninja_build(self):
-        assert "ninja -C out/Release pdfium" in self.df
+    def test_staging_copies_both_args_files(self):
+        assert "args.gn /staging/args.gn" in self.df
+        assert "args.gn /staging/args.static.gn" in self.df
 
 
-class TestMakeDockerfileArm64:
+class TestMakeDockerfileLinuxArm64:
     def setup_method(self):
         self.df = bp.make_dockerfile("7725", "arm64", "linux")
 
@@ -74,6 +103,48 @@ class TestMakeDockerfileArm64:
 
     def test_same_branch(self):
         assert "origin/chromium/7725" in self.df
+
+    def test_two_ninja_invocations(self):
+        assert "ninja -C out/Static pdfium" in self.df
+        assert "ninja -C out/Shared pdfium" in self.df
+
+
+class TestMakeDockerfileMuslAmd64:
+    def setup_method(self):
+        self.df = bp.make_dockerfile("7725", "amd64", "musl")
+
+    def test_musl_toolchain_downloaded(self):
+        assert "x86_64-linux-musl-cross.tgz" in self.df
+
+    def test_target_cpu_x64(self):
+        assert 'target_cpu = "x64"' in self.df
+
+    def test_is_musl_gn_arg(self):
+        assert "is_musl = true" in self.df
+
+    def test_two_ninja_invocations(self):
+        assert "ninja -C out/Static pdfium" in self.df
+        assert "ninja -C out/Shared pdfium" in self.df
+
+    def test_base_then_shared(self):
+        base_pos = self.df.index("--mode base")
+        shared_pos = self.df.index("--mode shared")
+        assert base_pos < shared_pos
+
+    def test_staging_contains_both_artifacts(self):
+        assert "libpdfium.so /staging/lib/" in self.df
+        assert "libpdfium.a /staging/lib/" in self.df
+
+
+class TestMakeDockerfileMuslArm64:
+    def setup_method(self):
+        self.df = bp.make_dockerfile("7725", "arm64", "musl")
+
+    def test_musl_toolchain_downloaded(self):
+        assert "aarch64-linux-musl-cross.tgz" in self.df
+
+    def test_target_cpu_arm64(self):
+        assert 'target_cpu = "arm64"' in self.df
 
 
 class TestMakeDockerfileDifferentVersions:

--- a/pdfium/tests/test_naming.py
+++ b/pdfium/tests/test_naming.py
@@ -4,11 +4,17 @@ import build_pdfium as bp
 
 
 class TestArchiveName:
-    def test_amd64(self):
+    def test_linux_amd64(self):
         assert bp.archive_name("linux", "amd64") == "pdfium-linux-x64.tgz"
 
-    def test_arm64(self):
+    def test_linux_arm64(self):
         assert bp.archive_name("linux", "arm64") == "pdfium-linux-arm64.tgz"
+
+    def test_musl_amd64(self):
+        assert bp.archive_name("musl", "amd64") == "pdfium-musl-x64.tgz"
+
+    def test_musl_arm64(self):
+        assert bp.archive_name("musl", "arm64") == "pdfium-musl-arm64.tgz"
 
     def test_format_is_platform_cpu(self):
         name = bp.archive_name("linux", "amd64")
@@ -17,11 +23,17 @@ class TestArchiveName:
 
 
 class TestStagingDirName:
-    def test_amd64(self):
+    def test_linux_amd64(self):
         assert bp.staging_dir_name("linux", "amd64") == "pdfium-linux-x64"
 
-    def test_arm64(self):
+    def test_linux_arm64(self):
         assert bp.staging_dir_name("linux", "arm64") == "pdfium-linux-arm64"
+
+    def test_musl_amd64(self):
+        assert bp.staging_dir_name("musl", "amd64") == "pdfium-musl-x64"
+
+    def test_musl_arm64(self):
+        assert bp.staging_dir_name("musl", "arm64") == "pdfium-musl-arm64"
 
     def test_no_extension(self):
         name = bp.staging_dir_name("linux", "amd64")


### PR DESCRIPTION
## Summary

- Every release archive now ships both a shared library (`libpdfium.so` / `.dylib`) and a static archive (`libpdfium.a`), produced from a single source checkout via a two-phase ninja build (`out/Static` with the base patch, then `out/Shared` after the `BUILD.gn` `component` -> `shared_library` rewrite).
- Default build matrix is now \`{linux, musl} x {amd64, arm64}\` — four archives per tag covering both glibc and musl runtimes.
- Patch scripts take a \`--mode {base,shared,all}\` flag so each ninja pass applies only the patches it needs.
- Adds \`MANUAL.md\` with a man-page-style reference for the build tooling, updates README.md and pdfium/README.md to describe the new artifact layout and libc compatibility matrix, and expands the pytest suite.

## Motivation

Downstream musl consumers (e.g. Rust binaries built for \`x86_64-unknown-linux-musl\` with \`+crt-static\`) cannot \`dlopen\` the glibc shared library and need either a musl-linked \`.so\` or the \`.a\` to link statically via \`pdfium-render/static\`.

## Test plan

- [x] \`pytest pdfium/tests/ -v\` — 72 tests pass
- [x] \`ruff check pdfium/\` / \`ruff format --check pdfium/\` clean
- [x] \`shellcheck pdfium/patches/*.sh\` clean
- [x] Trigger **Build PDFium** workflow with \`upload=true\` to produce the new \`pdfium-7725\` release from this branch once merged