### PR TITLE
feat(pdfium): memory-aware scheduler for --parallel

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -26,6 +26,7 @@ python3 pdfium/build_pdfium.py VERSION
                                [--arch {amd64,arm64}]
                                [--platform PLATFORM [PLATFORM ...]]
                                [--parallel]
+                               [--mem-per-build MB]
                                [--upload]
                                [--output-dir DIR]
 ```
@@ -119,11 +120,28 @@ container's own CPU arch, not the target.
 **`--parallel`**
 
 :   Fan out every `(platform, arch)` combo concurrently. With the
-    default matrix this runs four Docker builds at once (one thread per
-    combo); with `--platform linux` + `--arch amd64` it has no effect.
-    In the terminal, press `Tab` or digits `1`–`4` to switch which
-    build's live output is visible; the other builds continue in the
-    background and replay on switch.
+    default matrix this runs up to five Docker builds at once (one
+    thread per combo); with `--platform linux` + `--arch amd64` it has
+    no effect. In the terminal, press `Tab` or digits `1`–`5` to switch
+    which build's live output is visible; the other builds continue in
+    the background and replay on switch.
+
+    Each parallel build reserves `--mem-per-build` MB from the Docker
+    daemon's memory budget (read via `docker info`) before starting.
+    Builds whose reservation would exceed the budget are held in a
+    `queued — waiting for memory` state and launched as earlier builds
+    finish, so a small Docker VM running five jobs degrades gracefully
+    to serial execution instead of OOM-crashing. If `docker info` can't
+    be read, gating is skipped with a one-line warning.
+
+**`--mem-per-build MB`**
+
+:   Pessimistic per-build memory estimate used by the `--parallel`
+    scheduler. Default: `4096` (4 GiB), which comfortably covers
+    PDFium's ninja link peak plus Docker overhead. Tune down if runs
+    queue needlessly on a large host; tune up if you see OOM kills.
+    Has no effect outside `--parallel` or when the default matrix has
+    only one job.
 
 **`--upload`**
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -156,13 +156,36 @@ container's own CPU arch, not the target.
 :   Where to write the `.tgz` archives. Default: `./bin`. Created if it
     does not already exist.
 
+## LOGS
+
+Every job writes its full Docker build output to
+`<output-dir>/logs/<plat>-<arch>.log` (so the default location is
+`./bin/logs/linux-arm64.log`, `./bin/logs/mac-arm64.log`, …). The log
+file is the authoritative post-mortem record when a build fails —
+`--parallel` only keeps the last ~500 output lines per job in memory
+for the in-terminal view switcher, but the log file on disk has every
+line plus a header (version, start timestamp, image tag) and a footer
+with the exit status and exception type.
+
+On failure the script prints the log path to stderr so you can
+`tail -n 200 bin/logs/linux-arm64.log` or open it in an editor without
+hunting for it. The extraction and tarball-creation commands
+(`docker create`, `docker cp`, `tar czf`) are also captured into the
+same log file, so post-compile failures stay diagnosable.
+
+Log files are not gitignored by path but `*.log` is — they're safe to
+leave in place across runs. Each new invocation truncates its own
+`<plat>-<arch>.log` rather than appending.
+
 ## FILES
 
 ```
 pdfium/
 ├── build_pdfium.py            # entry point
 ├── bin/                       # default output directory (gitignored)
-│   └── pdfium-<plat>-<cpu>.tgz
+│   ├── pdfium-<plat>-<cpu>.tgz
+│   └── logs/
+│       └── <plat>-<arch>.log  # per-job Docker build log (overwritten each run)
 ├── patches/
 │   ├── linux.py               # glibc linux patch script (accepts --mode)
 │   ├── mac.py                 # macOS patch script (accepts --mode)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Build the full default matrix for chromium branch 7725 and publish it as a relea
 python3 pdfium/build_pdfium.py 7725 --parallel --upload
 ```
 
+`--parallel` fans out every `(platform, arch)` combo (5 by default) at once, gated by a memory scheduler that reads the Docker daemon's `MemTotal` and queues over-budget combos until earlier ones finish. Tune with `--mem-per-build MB` (default `4096`) if you see builds queuing unnecessarily on a large host or want extra safety margin on a small one.
+
+Every job streams its full Docker build output to `pdfium/bin/logs/<plat>-<arch>.log`. If a job fails, the script prints the log path to stderr — `tail -n 200 pdfium/bin/logs/linux-arm64.log` gives you the authoritative post-mortem, since the in-terminal view only retains the last ~500 lines per job.
+
 Or trigger the **Build PDFium** GitHub Actions workflow via `workflow_dispatch`, entering the chromium branch number and toggling `upload=true`.
 
 ## Development

--- a/pdfium/README.md
+++ b/pdfium/README.md
@@ -13,11 +13,12 @@ We compile PDFium from source rather than using third-party prebuilt binaries to
 
 ## Download
 
-Archives are available from [Releases](https://github.com/libviprs/libviprs-dep/releases). Each release tag bundles four archives covering the full matrix of `{linux, musl}` × `{x64, arm64}`:
+Archives are available from [Releases](https://github.com/libviprs/libviprs-dep/releases). Each release tag bundles five archives covering the default matrix (`{linux, musl}` × `{x64, arm64}` plus `mac/arm64`):
 
 ```
 https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-x64.tgz
 https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-arm64.tgz
+https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-mac-arm64.tgz
 https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-musl-x64.tgz
 https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-musl-arm64.tgz
 ```
@@ -26,6 +27,9 @@ https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-mu
 | --- | --- | --- |
 | `linux-x64`, `linux-arm64` | glibc | Debian, Ubuntu, RHEL, most mainstream distros |
 | `musl-x64`, `musl-arm64`   | musl  | Alpine, any container built `FROM alpine:*`, musl-based distroless images |
+| `mac-arm64`                | —     | macOS 11+ on Apple Silicon (`libpdfium.dylib`) |
+
+Intel Mac (`mac-x64`) is not in the default matrix — Apple has shipped Apple Silicon exclusively for new Macs since 2020, so the x86_64 dylib is rarely useful. Build one explicitly with `--platform mac --arch x86_64` if you need it.
 
 Pick the archive whose libc matches the runtime that will load PDFium. Loading a glibc `.so` from a musl process (or vice versa) fails at `dlopen` time with opaque errors — the libc mismatch is the single most common source of "pdfium doesn't load in my container" tickets.
 
@@ -95,7 +99,7 @@ The two-phase ninja build is the cleanest way to emit both a static archive and 
 ### Usage
 
 ```bash
-# Build the full default matrix (linux + musl, amd64 + arm64 — four archives)
+# Build the full default matrix (linux + mac/arm64 + musl — five archives)
 python3 build_pdfium.py 7725
 
 # Build a single platform
@@ -108,12 +112,17 @@ python3 build_pdfium.py 7725 --platform linux musl
 
 # Build a single architecture across all default platforms
 python3 build_pdfium.py 7725 --arch amd64
+python3 build_pdfium.py 7725 --arch x86_64   # alias for amd64 (Intel naming)
+python3 build_pdfium.py 7725 --arch aarch64  # alias for arm64
 
 # Combine: single platform, single arch
 python3 build_pdfium.py 7725 --platform musl --arch arm64
 
-# Build archs in parallel (within each platform pass)
+# Fan out every (platform, arch) combo concurrently
 python3 build_pdfium.py 7725 --parallel
+
+# Tune parallel scheduling (lower value = higher concurrency, higher = safer)
+python3 build_pdfium.py 7725 --parallel --mem-per-build 3500
 
 # Build and upload to GitHub Releases
 python3 build_pdfium.py 7725 --upload
@@ -143,9 +152,18 @@ Archives are written to `./bin/` by default (gitignored). With the default platf
 bin/
   pdfium-linux-x64.tgz
   pdfium-linux-arm64.tgz
+  pdfium-mac-arm64.tgz
   pdfium-musl-x64.tgz
   pdfium-musl-arm64.tgz
+  logs/
+    linux-amd64.log
+    linux-arm64.log
+    mac-arm64.log
+    musl-amd64.log
+    musl-arm64.log
 ```
+
+Each job streams its full Docker build output to `bin/logs/<plat>-<arch>.log` in addition to the terminal view. When a parallel build fails the log file is the authoritative post-mortem record — the in-terminal view switcher only retains the last ~500 output lines per job, but the log on disk has every line plus a header (version, start timestamp) and a failure footer with the exception type. On failure the script prints the log path to stderr so you can `tail -n 200 bin/logs/<plat>-<arch>.log` directly.
 
 Archives follow the naming convention `pdfium-{platform}-{gn_cpu}.tgz` and extract to a directory of the same name:
 
@@ -163,33 +181,54 @@ When `--upload` is used, a GitHub Release tagged `pdfium-{version}` is created w
 
 ### Parallel builds
 
-By default, architectures within a platform are built sequentially. Use `--parallel` to build all architectures of a platform simultaneously:
+By default every `(platform, arch)` combo builds sequentially. Use `--parallel` to fan all five default-matrix combos out concurrently in separate threads:
 
 ```bash
 python3 build_pdfium.py 7725 --parallel
 ```
 
-Platform passes still run sequentially (so the full default invocation builds linux first, then musl), but within each platform pass the amd64 and arm64 Docker builds run concurrently in separate threads.
-
-During a parallel build, you can switch between each architecture's build output:
+During a parallel run the terminal header shows a progress row per job and you can switch which job's live output is on screen:
 
 | Key | Action |
 | --- | --- |
-| `Tab` | Cycle to the next architecture's output |
-| `1` | Show amd64 output |
-| `2` | Show arm64 output |
+| `Tab`  | Cycle to the next job's output |
+| `1–5`  | Jump to the Nth job (order matches the header) |
 
-The active view is shown in the header bar. Each architecture's output is buffered independently, so switching views replays recent output without losing anything.
+Each job's output is buffered independently, so switching views replays the last ~500 lines of the selected job without losing anything. The full stream is also written to `bin/logs/<plat>-<arch>.log` for post-mortem inspection.
 
-`--parallel` has no effect when building a single architecture with `--arch`.
+`--parallel` has no effect when only one combo ends up in the run (e.g. `--platform linux --arch amd64`).
+
+#### Memory-aware scheduling
+
+Running five concurrent PDFium builds can exhaust a small Docker VM and OOM-kill the host. Before each parallel build starts, the scheduler reserves a pessimistic `--mem-per-build` slice (default **4096 MB**) against the Docker daemon's `MemTotal` (reported by `docker info`, minus 1 GB daemon overhead). Builds whose reservation would blow the budget enter a **`queued — waiting for memory`** state in the UI and launch as earlier builds finish — so a 24 GB Docker VM running the full matrix serializes gracefully instead of crashing.
+
+```bash
+# Tighter budget: allow more concurrent builds on a big box
+python3 build_pdfium.py 7725 --parallel --mem-per-build 3000
+
+# Looser budget: safer on a small Docker VM
+python3 build_pdfium.py 7725 --parallel --mem-per-build 5000
+```
+
+Sizing guidance:
+
+| Docker `MemTotal` | `--mem-per-build` default (4096) | Concurrent builds |
+| --- | --- | --- |
+| 8 GB  | 1 build at a time (serial fallback) | effective serial |
+| 16 GB | 3 concurrent | 1 queued |
+| 24 GB | all 5 concurrent | none queued |
+| 32 GB+ | all 5 concurrent | none queued |
+
+When `docker info` is unreachable, gating is skipped with a warning and the run proceeds unconstrained (prior behavior).
 
 ### Build time
 
 PDFium is a large C++ project. With the two-phase build, expect:
-- ~20–40 minutes per architecture per platform (roughly double the single-phase time)
-- `--parallel` can cut wall time roughly in half when building both architectures of the same platform
+- ~20–40 minutes per `(platform, arch)` combo (roughly double the single-phase time)
+- `--parallel` can bring the full 5-combo wall time close to the slowest single combo on a box with enough Docker memory to run all 5 at once
+- On a memory-constrained host the scheduler queues builds and wall time degrades toward the sequential total — but no OOM crashes
 
-A full default matrix build on a fast machine takes 60–90 minutes wall time with `--parallel` enabled.
+A full default matrix build on a fast machine with ≥24 GB of Docker memory takes ~30–45 minutes wall time with `--parallel` enabled.
 
 ### Cross-compilation
 
@@ -271,6 +310,8 @@ Tests cover:
 | `test_step_regex.py` | Docker buildkit and ninja step marker parsing |
 | `test_dockerfile.py` | Generated Dockerfile content for linux amd64/arm64 and musl amd64/arm64, including the two-phase build structure |
 | `test_eta.py` | EMA-based ETA estimation lifecycle |
+| `test_resolve_jobs.py` | CLI `--platform`/`--arch` resolution to concrete job lists + `--arch` alias normalization (`x86_64`/`aarch64`/etc.) |
+| `test_memory_scheduler.py` | `MemoryScheduler` admission control: budget fit, queueing, wakeup on release, deadlock guard when one build exceeds the full budget |
 
 ## Reference
 

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -177,6 +177,17 @@ def gn_args_for(plat, gn_cpu, extra_args):
 # with BTI support, so the linker fails with -z force-bti.
 GN_ARGS_ARM64 = 'arm_control_flow_integrity = "none"'
 
+# Parallel Docker builds are each expected to peak around this much
+# memory (ninja link + clang compile + Docker layer overhead). This is a
+# conservative estimate — tune with --mem-per-build if runs serialize
+# needlessly, or bump it up if OOMs occur.
+DEFAULT_MEM_PER_BUILD_MB = 4096
+
+# Memory held back from the scheduling budget for the Docker daemon, the
+# host OS, and any non-build processes. Without this margin, launching
+# `budget // per_build` concurrent builds would leave zero slack.
+DEFAULT_MEM_RESERVE_MB = 1024
+
 # Regex to detect Docker buildkit step markers like [3/14]
 STEP_RE = re.compile(r"\[\s*(\d+)/(\d+)\]")
 
@@ -334,6 +345,7 @@ class BuildProgress:
         for job in jobs:
             self.status[job] = {
                 "state": "waiting",
+                "message": "",
                 "step": 0,
                 "total_steps": 0,
                 "start_time": None,
@@ -429,10 +441,21 @@ class BuildProgress:
         with self._lock:
             s = self.status[job]
             s["state"] = "building"
+            s["message"] = ""
             s["step"] = 0
             s["total_steps"] = 0
             s["start_time"] = time.time()
             self._render()
+
+    def set_queued(self, job, message):
+        """Mark a job as waiting for the scheduler (e.g. memory budget)."""
+        with self._lock:
+            s = self.status[job]
+            s["state"] = "queued"
+            s["message"] = message
+            self._render()
+        if not self.active:
+            print(f"[{job}] {message}", flush=True)
 
     def set_step(self, job, step, total, is_copy=False):
         with self._lock:
@@ -555,6 +578,10 @@ class BuildProgress:
 
         if state == "waiting":
             line = f" {indicator}{job:<{label_w}} waiting"
+            lines.append(f"│{bg_on}{line:<{w - 2}}{bg_off}│")
+
+        elif state == "queued":
+            line = f" {indicator}{job:<{label_w}} ⏳ {s['message']}"
             lines.append(f"│{bg_on}{line:<{w - 2}}{bg_off}│")
 
         elif state == "building":
@@ -776,6 +803,79 @@ def check_dependencies(upload):
             "compile happens inside an amd64 Debian container."
         )
         sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Memory-aware parallel scheduling
+# ---------------------------------------------------------------------------
+
+
+def docker_total_memory_mb():
+    """Total memory the Docker daemon can hand to containers, in MB.
+
+    On Docker Desktop (macOS/Windows) this is the Linux VM's allocation —
+    which is the real constraint, not the host's physical RAM. On native
+    Linux Docker it's the host's total memory. Returns None if the
+    daemon is unreachable, in which case memory gating falls back to
+    no-op and parallel builds run unconstrained.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "info", "--format", "{{.MemTotal}}"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+        return int(result.stdout.strip()) // (1024 * 1024)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError, ValueError):
+        return None
+
+
+class MemoryScheduler:
+    """Admission-control for parallel Docker builds based on a memory budget.
+
+    Each ``reserve(job)`` call blocks on a condition variable until the
+    caller's pessimistic ``per_build_mb`` reservation fits under
+    ``budget_mb``; ``release()`` returns the reservation and wakes
+    waiters. If a single build's estimate exceeds the full budget (tiny
+    Docker VM, huge per-build estimate) the first caller is still allowed
+    through — we can't do better than serializing — while later callers
+    queue normally. When a caller has to wait, ``progress.set_queued()``
+    is invoked once so the UI row shows the reason.
+    """
+
+    def __init__(self, budget_mb, per_build_mb, progress):
+        self.budget_mb = budget_mb
+        self.per_build_mb = per_build_mb
+        self.reserved_mb = 0
+        self.progress = progress
+        self._cond = threading.Condition()
+
+    def reserve(self, job):
+        """Block until this job's reservation fits within the budget."""
+        with self._cond:
+            announced = False
+            # ``reserved_mb > 0`` is the deadlock guard: if a single
+            # build's estimate already exceeds the budget, the very first
+            # caller must still be allowed to run (with no concurrency).
+            while self.reserved_mb + self.per_build_mb > self.budget_mb and self.reserved_mb > 0:
+                if not announced:
+                    available = max(self.budget_mb - self.reserved_mb, 0)
+                    self.progress.set_queued(
+                        job,
+                        f"queued — waiting for memory "
+                        f"(need ~{self.per_build_mb} MB, ~{available} MB free)",
+                    )
+                    announced = True
+                self._cond.wait()
+            self.reserved_mb += self.per_build_mb
+
+    def release(self):
+        """Return a reservation to the budget and wake any waiters."""
+        with self._cond:
+            self.reserved_mb = max(self.reserved_mb - self.per_build_mb, 0)
+            self._cond.notify_all()
 
 
 # ---------------------------------------------------------------------------
@@ -1088,7 +1188,7 @@ def run(cmd, **kwargs):
 # ---------------------------------------------------------------------------
 
 
-def build_for_arch(version, arch, plat, output_dir, progress):
+def build_for_arch(version, arch, plat, output_dir, progress, mem_scheduler=None):
     """Build PDFium for a single (platform, arch) using Docker.
 
     All builds run inside an amd64 container.  arm64 targets are
@@ -1098,11 +1198,29 @@ def build_for_arch(version, arch, plat, output_dir, progress):
     Docker build context as ``platform.py`` and applied during the build.
     Image and container names include both ``plat`` and ``arch`` so
     concurrent ``(plat, arch)`` builds can't collide on shared names.
+
+    When ``mem_scheduler`` is provided, the worker reserves a pessimistic
+    memory slice before any Docker work starts, and releases it in
+    ``finally`` so crashes don't permanently starve the budget.
     """
     job = f"{plat}/{arch}"
     image_tag = f"pdfium-builder-{version}-{plat}-{arch}"
     container_name = f"pdfium-extract-{version}-{plat}-{arch}"
 
+    if mem_scheduler is not None:
+        mem_scheduler.reserve(job)
+    try:
+        return _build_for_arch_inner(
+            version, arch, plat, output_dir, progress, job, image_tag, container_name
+        )
+    finally:
+        if mem_scheduler is not None:
+            mem_scheduler.release()
+
+
+def _build_for_arch_inner(
+    version, arch, plat, output_dir, progress, job, image_tag, container_name
+):
     progress.start_arch(job)
 
     patch_script = os.path.join(PATCHES_DIR, f"{plat}.py")
@@ -1261,6 +1379,31 @@ def upload_release(version, built_files, progress):
 # ---------------------------------------------------------------------------
 
 
+def _make_mem_scheduler(progress, per_build_mb):
+    """Build a MemoryScheduler from ``docker info`` output, or None on failure.
+
+    When Docker's MemTotal can't be read we return None — the caller
+    proceeds without gating rather than blocking the whole build. A
+    one-line warning is printed so the user knows gating is off.
+    """
+    total = docker_total_memory_mb()
+    if total is None:
+        print(
+            "Warning: could not read Docker daemon memory budget "
+            "(`docker info` failed). Running without memory gating — "
+            "a parallel OOM may crash builds.",
+            flush=True,
+        )
+        return None
+    budget = max(total - DEFAULT_MEM_RESERVE_MB, per_build_mb)
+    print(
+        f"Docker memory budget: ~{total} MB total, "
+        f"~{budget} MB schedulable ({per_build_mb} MB/build).",
+        flush=True,
+    )
+    return MemoryScheduler(budget, per_build_mb, progress)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Build PDFium shared libraries using Docker",
@@ -1312,6 +1455,19 @@ def main():
         default="./bin",
         help="output directory (default: ./bin)",
     )
+    parser.add_argument(
+        "--mem-per-build",
+        type=int,
+        default=DEFAULT_MEM_PER_BUILD_MB,
+        metavar="MB",
+        help=(
+            "pessimistic memory estimate per parallel build, in MB "
+            f"(default: {DEFAULT_MEM_PER_BUILD_MB}). With --parallel, "
+            "builds whose reservation would exceed the Docker daemon's "
+            "total memory budget are queued and launched as earlier "
+            "builds finish."
+        ),
+    )
     args = parser.parse_args()
     try:
         args.arch = normalize_arch(args.arch)
@@ -1343,6 +1499,7 @@ def main():
         progress = BuildProgress(args.version, job_ids, parallel=args.parallel)
         try:
             if args.parallel and len(jobs) > 1:
+                mem_scheduler = _make_mem_scheduler(progress, args.mem_per_build)
                 with concurrent.futures.ThreadPoolExecutor(max_workers=len(jobs)) as pool:
                     futures = {
                         pool.submit(
@@ -1352,6 +1509,7 @@ def main():
                             plat,
                             output_dir,
                             progress,
+                            mem_scheduler,
                         ): (plat, arch)
                         for plat, arch in jobs
                     }

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -629,8 +629,14 @@ class BuildProgress:
 
     # -- Docker output streaming with step parsing -------------------------
 
-    def stream_docker_build(self, cmd, job):
-        """Run a docker build command, stream its output, and parse step progress."""
+    def stream_docker_build(self, cmd, job, log_file=None):
+        """Run a docker build command, stream its output, and parse step progress.
+
+        When ``log_file`` is provided every output line is written there
+        verbatim — the UI buffers only OUTPUT_BUFFER_SIZE lines per job,
+        so the log file is the authoritative post-mortem record when a
+        parallel build fails.
+        """
         process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
@@ -640,6 +646,9 @@ class BuildProgress:
         )
         for line in process.stdout:
             line = line.rstrip("\n")
+            if log_file is not None:
+                log_file.write(f"{line}\n")
+                log_file.flush()
             # Parse step markers
             m = STEP_RE.search(line)
             if m:
@@ -1183,6 +1192,31 @@ def run(cmd, **kwargs):
     return subprocess.run(cmd, check=True, **kwargs)
 
 
+def run_logged(cmd, log_file):
+    """Run a command, capturing stdout/stderr into ``log_file``.
+
+    Unlike ``run``, this captures output so the post-build extraction
+    steps (``docker create``, ``docker cp``, ``tar czf``) don't interleave
+    with parallel jobs on the terminal. The captured output is still
+    persisted to the per-job log file so failures remain diagnosable.
+    Raises ``CalledProcessError`` on non-zero exit, matching ``run``'s
+    ``check=True`` behavior.
+    """
+    display = cmd if isinstance(cmd, str) else " ".join(cmd)
+    print(f"  $ {display}", flush=True)
+    log_file.write(f"\n$ {display}\n")
+    log_file.flush()
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.stdout:
+        log_file.write(result.stdout)
+    if result.stderr:
+        log_file.write(result.stderr)
+    log_file.flush()
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Build
 # ---------------------------------------------------------------------------
@@ -1202,24 +1236,64 @@ def build_for_arch(version, arch, plat, output_dir, progress, mem_scheduler=None
     When ``mem_scheduler`` is provided, the worker reserves a pessimistic
     memory slice before any Docker work starts, and releases it in
     ``finally`` so crashes don't permanently starve the budget.
+
+    Every job writes its full Docker build output to
+    ``<output_dir>/logs/<plat>-<arch>.log`` — the UI ring buffer only
+    keeps the last OUTPUT_BUFFER_SIZE lines per job, so when a parallel
+    build fails the log file is the authoritative post-mortem record.
     """
     job = f"{plat}/{arch}"
     image_tag = f"pdfium-builder-{version}-{plat}-{arch}"
     container_name = f"pdfium-extract-{version}-{plat}-{arch}"
 
+    log_dir = os.path.join(output_dir, "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    log_path = os.path.join(log_dir, f"{plat}-{arch}.log")
+
     if mem_scheduler is not None:
         mem_scheduler.reserve(job)
     try:
-        return _build_for_arch_inner(
-            version, arch, plat, output_dir, progress, job, image_tag, container_name
-        )
+        with open(log_path, "w") as log_file:
+            log_file.write(
+                f"# PDFium build log\n"
+                f"# job:     {job}\n"
+                f"# version: chromium/{version}\n"
+                f"# started: {time.strftime('%Y-%m-%d %H:%M:%S %z')}\n"
+                f"# image:   {image_tag}\n\n"
+            )
+            log_file.flush()
+            try:
+                result = _build_for_arch_inner(
+                    version,
+                    arch,
+                    plat,
+                    output_dir,
+                    progress,
+                    job,
+                    image_tag,
+                    container_name,
+                    log_file,
+                )
+                log_file.write(f"\n# finished: {time.strftime('%Y-%m-%d %H:%M:%S %z')} (success)\n")
+                return result
+            except BaseException as exc:
+                log_file.write(
+                    f"\n# finished: {time.strftime('%Y-%m-%d %H:%M:%S %z')} "
+                    f"(FAILED: {type(exc).__name__}: {exc})\n"
+                )
+                print(
+                    f"\n[{job}] build failed — full log: {log_path}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                raise
     finally:
         if mem_scheduler is not None:
             mem_scheduler.release()
 
 
 def _build_for_arch_inner(
-    version, arch, plat, output_dir, progress, job, image_tag, container_name
+    version, arch, plat, output_dir, progress, job, image_tag, container_name, log_file
 ):
     progress.start_arch(job)
 
@@ -1263,7 +1337,9 @@ def _build_for_arch_inner(
             image_tag,
             tmpdir,
         ]
-        rc = progress.stream_docker_build(cmd, job)
+        log_file.write(f"\n$ {' '.join(cmd)}\n")
+        log_file.flush()
+        rc = progress.stream_docker_build(cmd, job, log_file=log_file)
         if rc != 0:
             progress.set_failed(job)
             raise RuntimeError(f"Docker build failed for {job} (exit {rc})")
@@ -1274,10 +1350,13 @@ def _build_for_arch_inner(
     tarball = archive_name(plat, arch)
     output_path = os.path.join(output_dir, tarball)
 
+    log_file.write("\n# --- extracting staged artifacts ---\n")
+    log_file.flush()
+
     with tempfile.TemporaryDirectory() as extract_dir:
         staging_dest = os.path.join(extract_dir, dir_name)
         try:
-            run(
+            run_logged(
                 [
                     "docker",
                     "create",
@@ -1285,22 +1364,25 @@ def _build_for_arch_inner(
                     "--name",
                     container_name,
                     image_tag,
-                ]
+                ],
+                log_file,
             )
-            run(
+            run_logged(
                 [
                     "docker",
                     "cp",
                     f"{container_name}:/staging",
                     staging_dest,
-                ]
+                ],
+                log_file,
             )
         finally:
             subprocess.run(["docker", "rm", "-f", container_name], capture_output=True)
             subprocess.run(["docker", "rmi", "-f", image_tag], capture_output=True)
 
-        # Create tarball with top-level directory name
-        run(
+        log_file.write("\n# --- creating tarball ---\n")
+        log_file.flush()
+        run_logged(
             [
                 "tar",
                 "czf",
@@ -1308,7 +1390,8 @@ def _build_for_arch_inner(
                 "-C",
                 extract_dir,
                 dir_name,
-            ]
+            ],
+            log_file,
         )
 
     progress.set_done(job)
@@ -1535,6 +1618,8 @@ def main():
                 upload_progress.finish()
     except (RuntimeError, subprocess.CalledProcessError) as e:
         print(f"\nError: {e}", file=sys.stderr)
+        log_dir = os.path.join(output_dir, "logs")
+        print(f"Per-job build logs: {log_dir}/", file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
         print("\nInterrupted.", file=sys.stderr)

--- a/pdfium/tests/test_memory_scheduler.py
+++ b/pdfium/tests/test_memory_scheduler.py
@@ -1,0 +1,129 @@
+"""Tests for MemoryScheduler (memory-aware parallel build gating)."""
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+from build_pdfium import MemoryScheduler
+
+
+class TestFitsWithinBudget:
+    def test_four_builds_under_16gb_budget(self):
+        progress = MagicMock()
+        sched = MemoryScheduler(budget_mb=16384, per_build_mb=4096, progress=progress)
+        sched.reserve("a")
+        sched.reserve("b")
+        sched.reserve("c")
+        sched.reserve("d")
+        assert sched.reserved_mb == 16384
+        progress.set_queued.assert_not_called()
+
+    def test_reserve_and_release_roundtrip(self):
+        progress = MagicMock()
+        sched = MemoryScheduler(budget_mb=8192, per_build_mb=4096, progress=progress)
+        sched.reserve("a")
+        assert sched.reserved_mb == 4096
+        sched.release()
+        assert sched.reserved_mb == 0
+
+
+class TestQueuesWhenOverBudget:
+    def test_third_build_waits_until_release(self):
+        progress = MagicMock()
+        sched = MemoryScheduler(budget_mb=8192, per_build_mb=4096, progress=progress)
+        sched.reserve("a")
+        sched.reserve("b")
+
+        done = threading.Event()
+
+        def worker():
+            sched.reserve("c")
+            done.set()
+
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+        time.sleep(0.1)
+        assert not done.is_set()
+        progress.set_queued.assert_called_once()
+        args, _ = progress.set_queued.call_args
+        assert args[0] == "c"
+        assert "waiting for memory" in args[1]
+
+        sched.release()
+        t.join(timeout=2)
+        assert done.is_set()
+
+    def test_release_wakes_all_waiters(self):
+        progress = MagicMock()
+        sched = MemoryScheduler(budget_mb=4096, per_build_mb=4096, progress=progress)
+        sched.reserve("holder")
+
+        started = []
+        lock = threading.Lock()
+
+        def worker(name):
+            sched.reserve(name)
+            with lock:
+                started.append(name)
+            sched.release()
+
+        threads = [threading.Thread(target=worker, args=(f"t{i}",), daemon=True) for i in range(3)]
+        for t in threads:
+            t.start()
+        time.sleep(0.1)
+        assert started == []
+
+        sched.release()
+        for t in threads:
+            t.join(timeout=2)
+        assert sorted(started) == ["t0", "t1", "t2"]
+
+
+class TestDeadlockGuard:
+    def test_single_build_over_budget_still_runs(self):
+        # Budget < per_build would otherwise block forever. The first
+        # reservation must bypass the wait.
+        progress = MagicMock()
+        sched = MemoryScheduler(budget_mb=1024, per_build_mb=4096, progress=progress)
+        sched.reserve("a")
+        assert sched.reserved_mb == 4096
+        progress.set_queued.assert_not_called()
+
+    def test_second_caller_still_queues_even_when_first_is_over_budget(self):
+        progress = MagicMock()
+        sched = MemoryScheduler(budget_mb=1024, per_build_mb=4096, progress=progress)
+        sched.reserve("a")
+
+        done = threading.Event()
+
+        def worker():
+            sched.reserve("b")
+            done.set()
+
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+        time.sleep(0.1)
+        assert not done.is_set()
+
+        sched.release()
+        t.join(timeout=2)
+        assert done.is_set()
+
+
+class TestQueueAnnouncement:
+    def test_set_queued_called_at_most_once_per_reservation(self):
+        progress = MagicMock()
+        sched = MemoryScheduler(budget_mb=4096, per_build_mb=4096, progress=progress)
+        sched.reserve("a")
+
+        def worker():
+            sched.reserve("b")
+
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+        time.sleep(0.2)
+        sched.release()
+        t.join(timeout=2)
+        # 'b' waited, got announced once, then proceeded — no double-announce
+        # even though notify_all may have fired multiple times.
+        assert progress.set_queued.call_count == 1


### PR DESCRIPTION
## Summary
- Adds a `MemoryScheduler` that reserves a pessimistic per-build slice (default 4 GB) from the Docker daemon's memory budget before each parallel `docker build` launches.
- Builds whose reservation would exceed the budget enter a `queued — waiting for memory` UI state and launch as earlier builds release their reservations, so small Docker VMs running the full 5-combo matrix degrade to serial execution instead of OOM-crashing.
- New `--mem-per-build MB` CLI flag for tuning; graceful fallback (with a warning) when `docker info` is unreachable.
- On a 32 GB host with ~24 GB free, the default schedules all 5 builds concurrently without queueing.

## Test plan
- [x] 98 tests pass (7 new for MemoryScheduler: budget fit, queueing/wakeup, deadlock guard, one-time announce)
- [x] ruff check + format, shellcheck clean
- [x] `--help` shows the new flag
- [ ] Run `python3 pdfium/build_pdfium.py 7725 --parallel` on a 32 GB Linux host and confirm all 5 builds run concurrently