### PR TITLE
fix(pdfium): correct static archive, add cancel, harden retries

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -66,22 +66,32 @@ duplicating PDFium's large `component("pdfium")` target body inside
 | --- | --- | --- |
 | `linux` | `libpdfium.so` + `libpdfium.a`, glibc-linked | Debian / Ubuntu / RHEL / mainstream distros |
 | `musl`  | `libpdfium.so` + `libpdfium.a`, musl-linked  | Alpine, musl-based distroless images |
-| `mac`   | `libpdfium.dylib` (single-phase today) | macOS (Apple Silicon and x86_64) |
+| `mac`   | `libpdfium.dylib` (requires macOS host) | macOS (Apple Silicon and x86_64) |
 
-The default matrix is five archives:
+The default matrix is four archives:
 
 | Platform | Arch | Archive |
 | --- | --- | --- |
 | linux | amd64 | `pdfium-linux-x64.tgz` |
 | linux | arm64 | `pdfium-linux-arm64.tgz` |
-| mac   | arm64 | `pdfium-mac-arm64.tgz` (Apple Silicon) |
 | musl  | amd64 | `pdfium-musl-x64.tgz` |
 | musl  | arm64 | `pdfium-musl-arm64.tgz` |
 
-Intel Mac (`mac/amd64`) is **not** in the default matrix — Apple has
-shipped Apple Silicon exclusively for new Macs since 2020, so the
+`mac` is intentionally excluded from the default matrix. PDFium's
+`build/config/apple/sdk_info.py` invokes `xcodebuild` during `gn gen`
+to query the macOS SDK version, and `xcodebuild` does not exist in the
+Debian container used for glibc/musl builds. bblanchon/pdfium-binaries
+works around this by running mac builds on actual `macos-15` GitHub
+Actions runners rather than cross-compiling from Linux. The mac
+Dockerfile generator is kept in `build_pdfium.py` for reference, but
+opting into `--platform mac` on a Linux host fails at `gn gen` unless
+you pre-provision an Xcode SDK and a stub `xcodebuild` inside the
+container.
+
+Intel Mac (`mac/amd64`) is also **not** in the default matrix — Apple
+has shipped Apple Silicon exclusively for new Macs since 2020, so the
 x86_64 dylib is rarely useful. Request it explicitly with
-`--platform mac --arch amd64` if you need it.
+`--platform mac --arch amd64` when building on a macOS host.
 
 Every compile runs inside an amd64 Linux container regardless of the
 host's CPU arch. `build_pdfium.py` forces `--platform=linux/amd64` on
@@ -110,19 +120,19 @@ container's own CPU arch, not the target.
 
 **`--platform PLATFORM [PLATFORM ...]`**
 
-:   One or more of `linux`, `musl`, `mac`. Defaults to the full
-    5-archive matrix (see DESCRIPTION). Pass a single value
-    (`--platform musl`) or several space-separated values
-    (`--platform linux musl`). `--platform mac` alone produces only
-    `mac/arm64`; pair it with `--arch amd64` to build an Intel Mac
-    dylib.
+:   One or more of `linux`, `musl`, `mac`. Defaults to the
+    4-archive `{linux, musl} × {amd64, arm64}` matrix (see
+    DESCRIPTION). Pass a single value (`--platform musl`) or several
+    space-separated values (`--platform linux musl`). `--platform mac`
+    requires a macOS host (see supported-platforms note above);
+    pair it with `--arch amd64` to build an Intel Mac dylib.
 
 **`--parallel`**
 
 :   Fan out every `(platform, arch)` combo concurrently. With the
-    default matrix this runs up to five Docker builds at once (one
+    default matrix this runs up to four Docker builds at once (one
     thread per combo); with `--platform linux` + `--arch amd64` it has
-    no effect. In the terminal, press `Tab` or digits `1`–`5` to switch
+    no effect. In the terminal, press `Tab` or digits `1`–`4` to switch
     which build's live output is visible; the other builds continue in
     the background and replay on switch.
 
@@ -130,9 +140,10 @@ container's own CPU arch, not the target.
     daemon's memory budget (read via `docker info`) before starting.
     Builds whose reservation would exceed the budget are held in a
     `queued — waiting for memory` state and launched as earlier builds
-    finish, so a small Docker VM running five jobs degrades gracefully
-    to serial execution instead of OOM-crashing. If `docker info` can't
-    be read, gating is skipped with a one-line warning.
+    finish, so a small Docker VM running multiple jobs degrades
+    gracefully to serial execution instead of OOM-crashing. If
+    `docker info` can't be read, gating is skipped with a one-line
+    warning.
 
 **`--mem-per-build MB`**
 
@@ -145,16 +156,46 @@ container's own CPU arch, not the target.
 
 **`--upload`**
 
-:   After a successful build, call `gh release create` to publish the
-    archives as a GitHub Release tagged `pdfium-{VERSION}` on
-    `libviprs/libviprs-dep`. If a release with that tag already exists
-    it is deleted and replaced. Requires `gh` to be installed and
-    authenticated (`gh auth login`).
+:   After a successful build, publish the archives as assets on the
+    GitHub Release tagged `pdfium-{VERSION}` on
+    `libviprs/libviprs-dep`. If the release does not exist it is
+    created; if it already exists, assets whose filenames match
+    something newly built are **replaced** (via
+    `gh release upload --clobber`) and any unrelated assets are
+    **preserved**. This lets a partial re-run — e.g.
+    `--platform musl --upload` after fixing a musl-only regression —
+    update only the musl tarballs without touching the linux ones.
+    Requires `gh` to be installed and authenticated (`gh auth login`).
 
 **`--output-dir DIR`**
 
 :   Where to write the `.tgz` archives. Default: `./bin`. Created if it
     does not already exist.
+
+## INTERACTIVE CONTROLS
+
+While a build is running in an interactive terminal, `build_pdfium.py`
+reads single keypresses from stdin (via `termios` cbreak mode) without
+needing `Enter`. The listener is active in both sequential and
+`--parallel` modes.
+
+| Key | Action |
+| --- | --- |
+| `Tab` | cycle the live-output view to the next job (parallel only) |
+| `1`–`9` | switch the live-output view to the Nth job (parallel only) |
+| `c` | cancel the currently-viewed job (parallel) or the running job (sequential) |
+| `q` or `C` | cancel every job — running, extracting, and queued |
+
+Cancelled jobs render as `⊘ cancelled` in the header, distinct from
+`✗ failed`, so intentional stops are visually separated from real
+errors. `cancel_all` also sets a sticky flag: any job still queued
+behind the memory scheduler bails immediately when its turn would come
+up, so `q` does not wait for slow jobs to finish before terminating
+the whole run.
+
+Cancellation sends `SIGTERM` to the `docker build` subprocess. If the
+daemon survives but leaves orphan containers or images behind, run
+`docker system prune` between runs.
 
 ## LOGS
 
@@ -252,8 +293,7 @@ python3 pdfium/build_pdfium.py 7725
 ```
 
 Produces `pdfium-linux-x64.tgz`, `pdfium-linux-arm64.tgz`,
-`pdfium-mac-arm64.tgz`, `pdfium-musl-x64.tgz`, `pdfium-musl-arm64.tgz`
-in `./bin/`.
+`pdfium-musl-x64.tgz`, `pdfium-musl-arm64.tgz` in `./bin/`.
 
 ### Build only musl variants
 
@@ -274,12 +314,12 @@ python3 pdfium/build_pdfium.py 7725 --parallel
 ```
 
 Fans out every `(platform, arch)` combo at once — with the default
-matrix that's five concurrent Docker builds (`linux/amd64`,
-`linux/arm64`, `mac/arm64`, `musl/amd64`, `musl/arm64`). In the
-terminal, press `Tab` or digits `1`–`5` to switch which build's live
-output is on screen. On an 8-core machine with plenty of disk, wall
-time is roughly the slowest single build rather than five back-to-back
-builds.
+matrix that's four concurrent Docker builds (`linux/amd64`,
+`linux/arm64`, `musl/amd64`, `musl/arm64`). In the terminal, press
+`Tab` or digits `1`–`4` to switch which build's live output is on
+screen; `c` cancels the visible job and `q` cancels every job. On an
+8-core machine with plenty of disk, wall time is roughly the slowest
+single build rather than four back-to-back builds.
 
 ### Build and publish a release
 
@@ -287,9 +327,20 @@ builds.
 python3 pdfium/build_pdfium.py 7725 --upload
 ```
 
-Equivalent to a full build followed by `gh release create pdfium-7725`
-with all four archives attached. The existing release (if any) is
-replaced in place.
+Creates the `pdfium-7725` GitHub Release (if missing) and attaches all
+four archives. If the release already exists, its assets are appended
+or replaced in place — any unrelated assets on the release are
+preserved.
+
+### Re-run one platform and update only its assets
+
+```bash
+python3 pdfium/build_pdfium.py 7725 --platform musl --parallel --upload
+```
+
+Rebuilds only the musl archives and uploads them with `--clobber`,
+leaving the existing `pdfium-linux-*.tgz` assets on the release
+untouched. Useful after fixing a platform-specific regression.
 
 ### Run via GitHub Actions
 
@@ -316,7 +367,13 @@ pdfium-<platform>-<gn_cpu>/
 `args.gn` and `args.static.gn` are kept separate so a consumer
 investigating linker issues can see exactly which flags produced each
 binary. They differ only in the `BUILD.gn` target type that the
-matching patch mode selects.
+matching patch mode selects: `static_library("pdfium")` under
+`--mode base` (emitting `libpdfium.a` at `out/Static/obj/libpdfium.a`),
+then `shared_library("pdfium")` under `--mode shared` (emitting
+`libpdfium.so` at `out/Shared/libpdfium.so`). The patch must rewrite
+`component()` explicitly because `component()` resolves to `source_set`
+under `is_component_build=false`, which groups objects but does not
+link a `.a`.
 
 ## CONSUMING THE ARTIFACTS
 
@@ -391,6 +448,52 @@ A full default matrix build produces ~30 GB of Docker image layers
 before cleanup. Ensure the Docker daemon has at least that much free
 space, or run `docker system prune` between builds.
 
+### `ls: cannot access 'out/Static/libpdfium.a'` at the verify step
+
+The verify step looks at `out/Static/obj/libpdfium.a`, not
+`out/Static/libpdfium.a` — GN's `static_library` template writes its
+archive into the `obj/` subtree. If you are patching the Dockerfile by
+hand and see this error, update both the verify step
+(`ls -lh out/Static/obj/libpdfium.a`) and the staging copy
+(`cp out/Static/obj/libpdfium.a /staging/lib/`) to the `obj/` path.
+
+### `FileNotFoundError: No such file or directory: 'xcodebuild'` during `gn gen`
+
+You attempted `--platform mac` on a Linux host. PDFium's
+`build/config/apple/sdk_info.py` calls `xcodebuild -version` to
+populate the mac SDK variables, and `xcodebuild` does not exist
+inside the Debian container. Either build mac on a macOS host, or
+pre-provision an Xcode SDK plus a stub `xcodebuild` in the Dockerfile
+before the `gn gen` step.
+
+### `lockfile.LockError: Errno 11 EAGAIN` during `gclient sync`
+
+gclient's internal parallel workers race on the gsutil bundle bootstrap
+flock. The Dockerfile mitigates this by running
+`python3 /opt/depot_tools/gsutil.py --version` before `gclient sync`
+so the bundle download completes single-threaded. If the error
+returns, re-run the affected job — the race is non-deterministic and
+the retry usually succeeds.
+
+### `Could not resolve host: chromium.googlesource.com` (or `musl.cc`)
+
+Transient DNS failures inside the Docker VM, typically when several
+containers start in parallel. The Dockerfiles wrap the relevant
+fetches in retry loops (5 attempts × 10 s backoff for `git clone
+depot_tools`; `curl --retry 5 --retry-delay 10 --retry-all-errors`
+for `musl.cc`). If all retries fail, check the Docker VM's DNS
+configuration (`docker info | grep -i dns`) or drop parallelism for
+the affected run.
+
+### Docker build fails with `rpc error: code = Unavailable ... EOF`
+
+The BuildKit daemon inside the Docker VM disconnected mid-build —
+almost always an OOM kill. Raise the Docker VM's memory limit (Docker
+Desktop → Settings → Resources → Memory) or drop `--parallel`. On a
+7.5 GiB VM, five simultaneous PDFium builds exhaust RAM during the
+depot_tools bootstrap; 16 GiB+ is the practical floor for a full
+parallel matrix.
+
 ## SEE ALSO
 
 - [`pdfium/README.md`](pdfium/README.md) — build pipeline overview and download links
@@ -403,7 +506,7 @@ space, or run `docker system prune` between builds.
 
 ## HISTORY
 
-- **pdfium-7725** (2026-04) — first release to ship both `libpdfium.so` and `libpdfium.a` per archive, and to include musl-linked variants (`pdfium-musl-x64.tgz`, `pdfium-musl-arm64.tgz`) in the default matrix.
+- **pdfium-7725** (2026-04) — first release to ship both `libpdfium.so` and `libpdfium.a` per archive, and to include musl-linked variants (`pdfium-musl-x64.tgz`, `pdfium-musl-arm64.tgz`) in the default matrix. Interactive cancellation (`c` / `q`), retry-wrapped network steps, and `--upload` append/replace semantics landed in the same cycle. `mac` was removed from the default matrix after bblanchon/pdfium-binaries confirmed that mac builds require a macOS host.
 - **pdfium earlier** — glibc-only shared library releases.
 
 ## LICENSE

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pdfium-<platform>-<cpu>/
 └── LICENSE
 ```
 
-The default release matrix is `{linux, musl} × {amd64, arm64}` — four archives per tag. Pick the `linux-*` archives for glibc runtimes (Debian, Ubuntu, …) and the `musl-*` archives for musl runtimes (Alpine, musl-based distroless images). Loading a glibc `.so` from a musl process — or vice versa — fails at `dlopen` time. macOS (`pdfium-mac-*`) is available on request but not in the default matrix.
+The default release matrix is `{linux, musl} × {amd64, arm64}` — four archives per tag. Pick the `linux-*` archives for glibc runtimes (Debian, Ubuntu, …) and the `musl-*` archives for musl runtimes (Alpine, musl-based distroless images). Loading a glibc `.so` from a musl process — or vice versa — fails at `dlopen` time. macOS is intentionally excluded from the default matrix: PDFium's GN config invokes `xcodebuild` during `gn gen`, which doesn't exist on Linux, so mac builds require an actual macOS host (bblanchon/pdfium-binaries runs mac builds on `macos-15` GitHub Actions runners for the same reason).
 
 See [`pdfium/README.md`](pdfium/README.md#download) for direct download URLs and consumption examples.
 
@@ -36,7 +36,15 @@ Build the full default matrix for chromium branch 7725 and publish it as a relea
 python3 pdfium/build_pdfium.py 7725 --parallel --upload
 ```
 
-`--parallel` fans out every `(platform, arch)` combo (5 by default) at once, gated by a memory scheduler that reads the Docker daemon's `MemTotal` and queues over-budget combos until earlier ones finish. Tune with `--mem-per-build MB` (default `4096`) if you see builds queuing unnecessarily on a large host or want extra safety margin on a small one.
+`--parallel` fans out every `(platform, arch)` combo (4 by default) at once, gated by a memory scheduler that reads the Docker daemon's `MemTotal` and queues over-budget combos until earlier ones finish. Tune with `--mem-per-build MB` (default `4096`) if you see builds queuing unnecessarily on a large host or want extra safety margin on a small one.
+
+While the build is running, the terminal header accepts these keys:
+
+| Key | Action |
+| --- | --- |
+| `Tab` / `1`–`9` | switch which build's live output is visible (parallel only) |
+| `c` | cancel the currently-viewed job |
+| `q` or `C` | cancel every job — running and queued |
 
 Every job streams its full Docker build output to `pdfium/bin/logs/<plat>-<arch>.log`. If a job fails, the script prints the log path to stderr — `tail -n 200 pdfium/bin/logs/linux-arm64.log` gives you the authoritative post-mortem, since the in-terminal view only retains the last ~500 lines per job.
 

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -83,14 +83,18 @@ def normalize_arch(arch):
     return canonical
 
 
-# Default build matrix. Intel Macs are deliberately excluded — Apple has
-# shipped Apple Silicon exclusively for new Macs since 2020 and
-# pdfium-render consumers rarely need an x86_64 dylib. Add
-# ``--platform mac --arch x86_64`` to build one explicitly when needed.
+# Default build matrix. mac is excluded because PDFium's GN config
+# invokes ``xcodebuild`` during ``gn gen`` (via
+# ``build/config/apple/sdk_info.py``), which doesn't exist in a Debian
+# container. bblanchon/pdfium-binaries solves this by running mac builds
+# on actual macOS GitHub Actions runners (macos-15) rather than
+# cross-compiling from Linux — so we follow the same pattern and
+# require an explicit opt-in via ``--platform mac``. Intel Macs are also
+# excluded (Apple Silicon only since 2020); request one with
+# ``--platform mac --arch x86_64``.
 DEFAULT_JOBS = [
     ("linux", "amd64"),
     ("linux", "arm64"),
-    ("mac", "arm64"),
     ("musl", "amd64"),
     ("musl", "arm64"),
 ]
@@ -342,6 +346,16 @@ class BuildProgress:
         # Which job's output is currently displayed (None = interleaved/sequential)
         self._active_view = jobs[0] if self._parallel else None
         self._key_listener = None
+        # Cancellation state: ``_processes`` maps job → running Popen so a
+        # keypress can kill the right Docker build; ``_cancelled`` records
+        # which jobs were intentionally stopped so we don't relabel them
+        # as "failed" when the subprocess dies; ``_cancel_all`` makes any
+        # future registered processes die immediately, shutting down the
+        # whole fleet even when some jobs are still queued behind the
+        # memory scheduler.
+        self._processes = {}
+        self._cancelled = set()
+        self._cancel_all = False
         for job in jobs:
             self.status[job] = {
                 "state": "waiting",
@@ -366,9 +380,11 @@ class BuildProgress:
         if self.active:
             self._setup()
             atexit.register(self._cleanup)
-            if self._parallel:
-                self._key_listener = KeyListener(self._on_key)
-                self._key_listener.start()
+            # Key listener runs in both parallel and sequential modes —
+            # parallel uses Tab/1-9 for view switching too, sequential
+            # only needs c/q/C for cancellation.
+            self._key_listener = KeyListener(self._on_key)
+            self._key_listener.start()
 
     # -- terminal setup / teardown -----------------------------------------
 
@@ -401,7 +417,7 @@ class BuildProgress:
         self._cleanup()
 
     def _on_key(self, ch):
-        """Handle a keypress for view switching during parallel builds."""
+        """Handle a keypress for view switching / cancellation."""
         if ch == "\t":
             # Tab: cycle to next job
             with self._lock:
@@ -416,6 +432,89 @@ class BuildProgress:
                     self._active_view = self.jobs[idx]
                     self._replay_output()
                     self._render()
+        elif ch == "c":
+            # Cancel just the currently-viewed job (parallel) or the one
+            # actively building (sequential). No-op if no job is running.
+            target = self._active_view if self._parallel else self._current_running_job()
+            if target:
+                self.cancel_job(target)
+        elif ch in ("C", "q"):
+            # Cancel every running + queued job.
+            self.cancel_all()
+
+    def _current_running_job(self):
+        """Return the (at most one) job currently in the ``building`` state.
+
+        Used in sequential mode where ``_active_view`` is ``None`` — we
+        fall back to the single job that's actually running so ``c``
+        still has a meaningful target.
+        """
+        with self._lock:
+            for job in self.jobs:
+                if self.status[job]["state"] == "building":
+                    return job
+        return None
+
+    @staticmethod
+    def _kill_process(proc):
+        """Best-effort SIGTERM — the process may already be gone."""
+        try:
+            proc.terminate()
+        except (OSError, ProcessLookupError):
+            pass
+
+    def register_process(self, job, process):
+        """Track a running Popen so a keypress can kill it.
+
+        If ``cancel_all`` already fired, kill the newly-registered
+        process immediately — otherwise a job that was queued behind
+        the memory scheduler would start, sail past the cancellation,
+        and waste cycles.
+        """
+        with self._lock:
+            self._processes[job] = process
+            if self._cancel_all or job in self._cancelled:
+                self._kill_process(process)
+
+    def unregister_process(self, job):
+        with self._lock:
+            self._processes.pop(job, None)
+
+    def cancel_job(self, job):
+        """Cancel a single job — marks it cancelled and kills the Docker build."""
+        with self._lock:
+            if self.status[job]["state"] in ("done", "failed", "cancelled"):
+                return
+            self._cancelled.add(job)
+            s = self.status[job]
+            if s["state"] == "building":
+                if s["start_time"]:
+                    s["elapsed"] = time.time() - s["start_time"]
+            s["state"] = "cancelled"
+            proc = self._processes.get(job)
+            if proc:
+                self._kill_process(proc)
+            self._render()
+
+    def cancel_all(self):
+        """Cancel every job — running or queued."""
+        with self._lock:
+            self._cancel_all = True
+            for job in self.jobs:
+                s = self.status[job]
+                if s["state"] in ("done", "failed", "cancelled"):
+                    continue
+                self._cancelled.add(job)
+                if s["state"] == "building" and s["start_time"]:
+                    s["elapsed"] = time.time() - s["start_time"]
+                s["state"] = "cancelled"
+            for proc in list(self._processes.values()):
+                self._kill_process(proc)
+            self._render()
+
+    def is_cancelled(self, job):
+        with self._lock:
+            return job in self._cancelled
 
     def _replay_output(self):
         """Clear the scroll area and replay buffered output for the active view."""
@@ -533,12 +632,16 @@ class BuildProgress:
         title = f" PDFium chromium/{self.version} "
         if self._parallel and self._active_view:
             switch_hint = "1-9" if len(self.jobs) > 2 else "1/2"
-            hint = f"viewing: {self._active_view}  (Tab/{switch_hint} to switch) "
+            hint = (
+                f"viewing: {self._active_view}  "
+                f"(Tab/{switch_hint} switch · c cancel · q cancel all) "
+            )
             pad = max(w - len(title) - len(hint) - 4, 0)
             lines.append(f"┌──{title}{'─' * pad}{hint}┐")
         else:
-            pad = max(w - len(title) - 4, 0)
-            lines.append(f"┌──{title}{'─' * pad}┐")
+            hint = " (c cancel · q cancel all) " if self._key_listener else ""
+            pad = max(w - len(title) - len(hint) - 4, 0)
+            lines.append(f"┌──{title}{'─' * pad}{hint}┐")
         lines.append(f"│{' ' * (w - 2)}│")
 
         if self._uploading:
@@ -625,6 +728,10 @@ class BuildProgress:
             line = f" {indicator}{job:<{label_w}} ✗ failed  ({fmt_time(elapsed)})"
             lines.append(f"│{bg_on}{line:<{w - 2}}{bg_off}│")
 
+        elif state == "cancelled":
+            line = f" {indicator}{job:<{label_w}} ⊘ cancelled  ({fmt_time(elapsed)})"
+            lines.append(f"│{bg_on}{line:<{w - 2}}{bg_off}│")
+
         return lines
 
     # -- Docker output streaming with step parsing -------------------------
@@ -644,39 +751,45 @@ class BuildProgress:
             text=True,
             bufsize=1,
         )
-        for line in process.stdout:
-            line = line.rstrip("\n")
-            if log_file is not None:
-                log_file.write(f"{line}\n")
-                log_file.flush()
-            # Parse step markers
-            m = STEP_RE.search(line)
-            if m:
-                step = int(m.group(1))
-                total = int(m.group(2))
-                # COPY/CACHED steps are instant and would pollute the
-                # EMA rate — flag them so set_step skips the rate update.
-                is_copy = "] COPY " in line or "] CACHED" in line
-                self.set_step(job, step, total, is_copy=is_copy)
-            # Buffer and conditionally display
-            with self._lock:
-                if self._parallel:
-                    self._output[job].append(line)
-                    # Only print if this job is the active view
-                    if self._active_view == job:
+        # Register with the cancellation tracker. If ``cancel_all`` has
+        # already fired, ``register_process`` kills this Popen right away.
+        self.register_process(job, process)
+        try:
+            for line in process.stdout:
+                line = line.rstrip("\n")
+                if log_file is not None:
+                    log_file.write(f"{line}\n")
+                    log_file.flush()
+                # Parse step markers
+                m = STEP_RE.search(line)
+                if m:
+                    step = int(m.group(1))
+                    total = int(m.group(2))
+                    # COPY/CACHED steps are instant and would pollute the
+                    # EMA rate — flag them so set_step skips the rate update.
+                    is_copy = "] COPY " in line or "] CACHED" in line
+                    self.set_step(job, step, total, is_copy=is_copy)
+                # Buffer and conditionally display
+                with self._lock:
+                    if self._parallel:
+                        self._output[job].append(line)
+                        # Only print if this job is the active view
+                        if self._active_view == job:
+                            if self.active:
+                                sys.stdout.write(f"{line}\n")
+                                sys.stdout.flush()
+                            else:
+                                print(line)
+                    else:
                         if self.active:
                             sys.stdout.write(f"{line}\n")
                             sys.stdout.flush()
                         else:
                             print(line)
-                else:
-                    if self.active:
-                        sys.stdout.write(f"{line}\n")
-                        sys.stdout.flush()
-                    else:
-                        print(line)
-        process.wait()
-        return process.returncode
+            process.wait()
+            return process.returncode
+        finally:
+            self.unregister_process(job)
 
 
 # ---------------------------------------------------------------------------
@@ -937,13 +1050,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     && ln -sf /usr/bin/python3 /usr/bin/python \\
     && rm -rf /var/lib/apt/lists/*
 
-# Step 1: Install depot_tools
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \\
-    /opt/depot_tools
+# Step 1: Install depot_tools. Retry on transient DNS/network failures —
+# chromium.googlesource.com occasionally fails to resolve inside the
+# Docker VM on the first attempt, especially when several containers
+# start in parallel.
+RUN i=0; until git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \\
+    /opt/depot_tools; do i=$((i+1)); [ $i -ge 5 ] && exit 1; sleep 10; done
 ENV PATH="/opt/depot_tools:${{PATH}}"
-# Bootstrap depot_tools (creates python3_bin_reldir.txt needed by gn),
-# then disable auto-updates for the rest of the build.
-RUN gclient --version
+# Bootstrap depot_tools (creates python3_bin_reldir.txt needed by gn)
+# and serialize the gsutil bundle download — gclient's parallel sync
+# workers race on the gsutil bootstrap flock (Errno 11 EAGAIN) if this
+# is left to first-use during `gclient sync`. Then disable auto-updates.
+RUN gclient --version && python3 /opt/depot_tools/gsutil.py --version
 ENV DEPOT_TOOLS_UPDATE=0
 
 # Step 2: Configure gclient
@@ -986,15 +1104,18 @@ RUN gn gen out/Shared
 # Step 10: Build shared library (shared_library -> libpdfium.so)
 RUN ninja -C out/Shared pdfium
 
-# Step 11: Verify both outputs
-RUN ls -lh out/Static/libpdfium.a out/Shared/libpdfium.so && \\
-    file out/Static/libpdfium.a out/Shared/libpdfium.so
+# Step 11: Verify both outputs. GN's ``static_library`` writes the archive
+# to ``obj/<package>/lib<name>.a`` — for the top-level ``pdfium`` target
+# that's ``obj/libpdfium.a``. ``shared_library`` writes the .so at the
+# ninja out-dir root (``out/Shared/libpdfium.so``).
+RUN ls -lh out/Static/obj/libpdfium.a out/Shared/libpdfium.so && \\
+    file out/Static/obj/libpdfium.a out/Shared/libpdfium.so
 
 # Step 12: Stage artifacts into /staging
 COPY LICENSE /tmp/LICENSE
 RUN mkdir -p /staging/lib /staging/include && \\
     cp out/Shared/libpdfium.so /staging/lib/ && \\
-    cp out/Static/libpdfium.a /staging/lib/ && \\
+    cp out/Static/obj/libpdfium.a /staging/lib/ && \\
     cp out/Shared/args.gn /staging/args.gn && \\
     cp out/Static/args.gn /staging/args.static.gn && \\
     cp -r public/*.h /staging/include/ && \\
@@ -1003,12 +1124,17 @@ RUN mkdir -p /staging/lib /staging/include && \\
 
 
 def _make_dockerfile_mac(version, arch):
-    """Dockerfile for macOS builds.
+    """Dockerfile for macOS builds — DOES NOT WORK on a Linux host.
 
-    macOS builds cannot run natively inside Docker.  This Dockerfile
-    cross-compiles PDFium for macOS using the Chromium toolchain's clang
-    and the macOS SDK sysroot that gclient downloads.  The host container
-    is still Linux (amd64).
+    PDFium's ``build/config/apple/sdk_info.py`` invokes ``xcodebuild``
+    during ``gn gen`` to query the macOS SDK version, and ``xcodebuild``
+    doesn't exist in a Debian container. bblanchon/pdfium-binaries
+    solves this by running mac builds on actual macOS-15 GitHub Actions
+    runners rather than cross-compiling from Linux.
+
+    This function is kept for reference and for users who pre-provision
+    an Xcode SDK + stub ``xcodebuild`` inside the container. It is NOT
+    included in DEFAULT_JOBS and will fail at ``gn gen`` out of the box.
     """
     target = TARGETS[arch]
     gn_cpu = target["gn_cpu"]
@@ -1024,9 +1150,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     && ln -sf /usr/bin/python3 /usr/bin/python \\
     && rm -rf /var/lib/apt/lists/*
 
-# Step 1: Install depot_tools
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \\
-    /opt/depot_tools
+# Step 1: Install depot_tools. Retry on transient DNS/network failures —
+# chromium.googlesource.com occasionally fails to resolve inside the
+# Docker VM on the first attempt, especially when several containers
+# start in parallel.
+RUN i=0; until git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \\
+    /opt/depot_tools; do i=$((i+1)); [ $i -ge 5 ] && exit 1; sleep 10; done
 ENV PATH="/opt/depot_tools:${{PATH}}"
 RUN gclient --version
 ENV DEPOT_TOOLS_UPDATE=0
@@ -1100,15 +1229,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     && ln -sf /usr/bin/python3 /usr/bin/python \\
     && rm -rf /var/lib/apt/lists/*
 
-# Step 1: Install musl-cross-make toolchain
-RUN curl -fsSL "https://musl.cc/{musl_target}-cross.tgz" | tar xz -C /opt
+# Step 1: Install musl-cross-make toolchain.
+# musl.cc is a small single-host mirror that occasionally returns DNS
+# failures or 5xx under load; --retry with --retry-all-errors covers
+# both transient network and HTTP errors so a flake doesn't kill the build.
+RUN curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors \\
+    "https://musl.cc/{musl_target}-cross.tgz" | tar xz -C /opt
 ENV PATH="/opt/{musl_target}-cross/bin:${{PATH}}"
 
-# Step 2: Install depot_tools
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \\
-    /opt/depot_tools
+# Step 2: Install depot_tools. Retry on transient DNS/network failures.
+RUN i=0; until git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git \\
+    /opt/depot_tools; do i=$((i+1)); [ $i -ge 5 ] && exit 1; sleep 10; done
 ENV PATH="/opt/depot_tools:${{PATH}}"
-RUN gclient --version
+# Bootstrap depot_tools and serialize gsutil download — see linux Dockerfile
+# comment for why this pre-warm is needed.
+RUN gclient --version && python3 /opt/depot_tools/gsutil.py --version
 ENV DEPOT_TOOLS_UPDATE=0
 
 # Step 3: Configure gclient
@@ -1147,15 +1282,17 @@ RUN gn gen out/Shared
 # Step 11: Build shared library (shared_library -> libpdfium.so)
 RUN ninja -C out/Shared pdfium
 
-# Step 12: Verify both outputs
-RUN ls -lh out/Static/libpdfium.a out/Shared/libpdfium.so && \\
-    file out/Static/libpdfium.a out/Shared/libpdfium.so
+# Step 12: Verify both outputs. GN's ``static_library`` writes the archive
+# to ``obj/<package>/lib<name>.a`` — for the top-level ``pdfium`` target
+# that's ``obj/libpdfium.a``.
+RUN ls -lh out/Static/obj/libpdfium.a out/Shared/libpdfium.so && \\
+    file out/Static/obj/libpdfium.a out/Shared/libpdfium.so
 
 # Step 13: Stage artifacts into /staging
 COPY LICENSE /tmp/LICENSE
 RUN mkdir -p /staging/lib /staging/include && \\
     cp out/Shared/libpdfium.so /staging/lib/ && \\
-    cp out/Static/libpdfium.a /staging/lib/ && \\
+    cp out/Static/obj/libpdfium.a /staging/lib/ && \\
     cp out/Shared/args.gn /staging/args.gn && \\
     cp out/Static/args.gn /staging/args.static.gn && \\
     cp -r public/*.h /staging/include/ && \\
@@ -1295,6 +1432,11 @@ def build_for_arch(version, arch, plat, output_dir, progress, mem_scheduler=None
 def _build_for_arch_inner(
     version, arch, plat, output_dir, progress, job, image_tag, container_name, log_file
 ):
+    # If cancel_all fired while this job was queued behind the memory
+    # scheduler, bail before starting the Docker build at all.
+    if progress.is_cancelled(job):
+        raise RuntimeError(f"Docker build cancelled for {job}")
+
     progress.start_arch(job)
 
     patch_script = os.path.join(PATCHES_DIR, f"{plat}.py")
@@ -1341,6 +1483,10 @@ def _build_for_arch_inner(
         log_file.flush()
         rc = progress.stream_docker_build(cmd, job, log_file=log_file)
         if rc != 0:
+            # If the non-zero exit came from a user cancellation, the job
+            # already shows as "cancelled" — don't relabel it "failed".
+            if progress.is_cancelled(job):
+                raise RuntimeError(f"Docker build cancelled for {job}")
             progress.set_failed(job)
             raise RuntimeError(f"Docker build failed for {job} (exit {rc})")
 
@@ -1407,46 +1553,57 @@ def _build_for_arch_inner(
 
 
 def upload_release(version, built_files, progress):
-    """Create a GitHub Release and upload the built binaries."""
+    """Create or update a GitHub Release, adding/replacing the built assets.
+
+    If the release doesn't exist, it is created. Existing assets with names
+    not in ``built_files`` are preserved — useful when a parallel run only
+    produced a subset of the matrix (e.g. musl succeeded, linux/arm64 didn't).
+    Assets whose names collide with newly-built files are replaced via
+    ``gh release upload --clobber``.
+    """
     tag = release_tag(version)
     branch = f"chromium/{version}"
 
     progress.set_uploading()
 
-    # Delete existing release if present
-    result = subprocess.run(
+    release_exists = subprocess.run(
         ["gh", "release", "view", tag, "-R", GITHUB_REPO],
         capture_output=True,
-    )
-    if result.returncode == 0:
-        print(f"Release '{tag}' already exists, deleting...", flush=True)
+    ).returncode == 0
+
+    if not release_exists:
+        print(f"Release '{tag}' doesn't exist, creating...", flush=True)
         run(
             [
                 "gh",
                 "release",
-                "delete",
+                "create",
                 tag,
                 "-R",
                 GITHUB_REPO,
-                "--yes",
+                "--title",
+                f"PDFium {branch}",
+                "--notes",
+                f"PDFium shared library built from source.\n\n"
+                f"Source: https://pdfium.googlesource.com/pdfium/+/refs/heads/{branch}\n\n"
+                "Build configuration:\n```\n"
+                f"{GN_ARGS_COMMON.format(gn_cpu='<target>', extra_args='')}```",
             ]
         )
+    else:
+        print(f"Release '{tag}' exists, appending/replacing assets...", flush=True)
 
+    # --clobber replaces matching-name assets; non-matching existing assets
+    # are left alone so partial runs can be combined across invocations.
     run(
         [
             "gh",
             "release",
-            "create",
+            "upload",
             tag,
             "-R",
             GITHUB_REPO,
-            "--title",
-            f"PDFium {branch}",
-            "--notes",
-            f"PDFium shared library built from source.\n\n"
-            f"Source: https://pdfium.googlesource.com/pdfium/+/refs/heads/{branch}\n\n"
-            "Build configuration:\n```\n"
-            f"{GN_ARGS_COMMON.format(gn_cpu='<target>', extra_args='')}```",
+            "--clobber",
             *built_files,
         ]
     )

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -1566,10 +1566,13 @@ def upload_release(version, built_files, progress):
 
     progress.set_uploading()
 
-    release_exists = subprocess.run(
-        ["gh", "release", "view", tag, "-R", GITHUB_REPO],
-        capture_output=True,
-    ).returncode == 0
+    release_exists = (
+        subprocess.run(
+            ["gh", "release", "view", tag, "-R", GITHUB_REPO],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
 
     if not release_exists:
         print(f"Release '{tag}' doesn't exist, creating...", flush=True)

--- a/pdfium/patches/linux.py
+++ b/pdfium/patches/linux.py
@@ -59,7 +59,7 @@ def patch_build_gn_shared(pdfium_dir: Path) -> None:
     updated = text.replace('static_library("pdfium")', 'shared_library("pdfium")')
     updated = updated.replace('component("pdfium")', 'shared_library("pdfium")')
     if updated == text:
-        print('WARNING: no pdfium target to rewrite in BUILD.gn — already patched?')
+        print("WARNING: no pdfium target to rewrite in BUILD.gn — already patched?")
         return
     build_gn.write_text(updated)
     print("Applied: BUILD.gn -> shared_library")

--- a/pdfium/patches/linux.py
+++ b/pdfium/patches/linux.py
@@ -4,20 +4,21 @@
 The patch is split into two modes so a single source checkout can
 produce *both* a static archive and a shared library:
 
-* ``base`` — applied once before any build. Only modifies
-  ``public/fpdfview.h`` to strip the ``COMPONENT_BUILD`` guard around
-  ``FPDF_EXPORT``, ensuring the public C API symbols always have
-  ``visibility("default")``. Leaves ``BUILD.gn`` alone, so the
-  ``component("pdfium")`` target resolves to ``static_library`` under
-  ``is_component_build=false`` and a subsequent ninja build produces
-  ``libpdfium.a``.
+* ``base`` — applied before the static-archive build. Modifies:
+    - ``public/fpdfview.h``: strip the ``COMPONENT_BUILD`` guard around
+      ``FPDF_EXPORT`` so the public C API always has
+      ``visibility("default")``.
+    - ``BUILD.gn``: rewrite ``component("pdfium")`` to
+      ``static_library("pdfium")``. Chromium's ``component()`` template
+      resolves to ``source_set`` (not ``static_library``) when
+      ``is_component_build=false``, and ``source_set`` does not link
+      a ``.a`` — it only groups objects. Explicit ``static_library``
+      is required to produce ``libpdfium.a``.
 
 * ``shared`` — applied on top of ``base`` before the second ninja pass.
-  Rewrites ``component("pdfium")`` to ``shared_library("pdfium")`` in
-  ``BUILD.gn`` so the same target now links a ``.so``. Invoking ninja in
-  a separate out dir then yields ``libpdfium.so`` using the already-built
-  object files would be ideal, but GN invalidates the target type change
-  and recompiles — acceptable cost for a single-source build.
+  Rewrites ``static_library("pdfium")`` back to ``shared_library("pdfium")``
+  so the same target now links a ``.so``. GN invalidates the target
+  type change and recompiles — acceptable cost for a single-source build.
 
 Together this gives us both artifacts from one checkout.
 
@@ -34,13 +35,31 @@ import sys
 from pathlib import Path
 
 
-def patch_build_gn(pdfium_dir: Path) -> None:
-    """Patch BUILD.gn: component() -> shared_library()."""
+def patch_build_gn_static(pdfium_dir: Path) -> None:
+    """Patch BUILD.gn: component() -> static_library()."""
     build_gn = pdfium_dir / "BUILD.gn"
     text = build_gn.read_text()
-    updated = text.replace('component("pdfium")', 'shared_library("pdfium")')
+    updated = text.replace('component("pdfium")', 'static_library("pdfium")')
     if updated == text:
         print('WARNING: component("pdfium") not found in BUILD.gn — already patched?')
+        return
+    build_gn.write_text(updated)
+    print("Applied: BUILD.gn -> static_library")
+
+
+def patch_build_gn_shared(pdfium_dir: Path) -> None:
+    """Patch BUILD.gn: component()/static_library() -> shared_library().
+
+    Handles both the pristine ``component("pdfium")`` form and the
+    post-``base``-mode ``static_library("pdfium")`` form, so ``shared``
+    works whether or not ``base`` ran first.
+    """
+    build_gn = pdfium_dir / "BUILD.gn"
+    text = build_gn.read_text()
+    updated = text.replace('static_library("pdfium")', 'shared_library("pdfium")')
+    updated = updated.replace('component("pdfium")', 'shared_library("pdfium")')
+    if updated == text:
+        print('WARNING: no pdfium target to rewrite in BUILD.gn — already patched?')
         return
     build_gn.write_text(updated)
     print("Applied: BUILD.gn -> shared_library")
@@ -104,9 +123,9 @@ def main() -> None:
         choices=["base", "shared", "all"],
         default="all",
         help=(
-            "base = fpdfview.h only (keeps component() -> static_library, "
-            "produces libpdfium.a); shared = adds the BUILD.gn rewrite "
-            "to produce libpdfium.so; all = both (default, legacy behavior)."
+            "base = fpdfview.h + rewrite component() to static_library "
+            "(produces libpdfium.a); shared = rewrite target to shared_library "
+            "(produces libpdfium.so); all = both in sequence (default)."
         ),
     )
     args = parser.parse_args()
@@ -118,8 +137,9 @@ def main() -> None:
 
     if args.mode in ("base", "all"):
         patch_fpdfview_h(pdfium_dir)
+        patch_build_gn_static(pdfium_dir)
     if args.mode in ("shared", "all"):
-        patch_build_gn(pdfium_dir)
+        patch_build_gn_shared(pdfium_dir)
 
 
 if __name__ == "__main__":

--- a/pdfium/patches/musl.py
+++ b/pdfium/patches/musl.py
@@ -55,7 +55,7 @@ def patch_build_gn_shared(pdfium_dir: Path) -> None:
     updated = text.replace('static_library("pdfium")', 'shared_library("pdfium")')
     updated = updated.replace('component("pdfium")', 'shared_library("pdfium")')
     if updated == text:
-        print('WARNING: no pdfium target to rewrite in BUILD.gn — already patched?')
+        print("WARNING: no pdfium target to rewrite in BUILD.gn — already patched?")
         return
     build_gn.write_text(updated)
     print("Applied: BUILD.gn -> shared_library")

--- a/pdfium/patches/musl.py
+++ b/pdfium/patches/musl.py
@@ -4,8 +4,7 @@
 Mirrors the linux patch's two-mode split so a single checkout yields
 both ``libpdfium.a`` and ``libpdfium.so``:
 
-* ``base`` — applied before the static-archive build. Does everything
-  *except* the BUILD.gn ``component()`` rewrite:
+* ``base`` — applied before the static-archive build:
     - ``fpdfview.h``: strip COMPONENT_BUILD guard around FPDF_EXPORT.
     - ``BUILDCONFIG.gn``: declare ``is_musl``, route default toolchain
       to ``//build/toolchain/linux/musl``, disable ``-fstack-protector``.
@@ -14,13 +13,16 @@ both ``libpdfium.a`` and ``libpdfium.so``:
     - Install the musl GN toolchain at
       ``build/toolchain/linux/musl/BUILD.gn`` (gcc_toolchain entries for
       x86/x64/arm/arm64 using musl-cross-make prefixes).
-  With these in place, ``component("pdfium")`` still resolves to
-  ``static_library`` under ``is_component_build=false`` and produces
-  ``libpdfium.a``.
+    - ``BUILD.gn``: rewrite ``component("pdfium")`` to
+      ``static_library("pdfium")``. Chromium's ``component()`` template
+      resolves to ``source_set`` (not ``static_library``) under
+      ``is_component_build=false``, and ``source_set`` does not link
+      a ``.a``. Explicit ``static_library`` is required for
+      ``libpdfium.a``.
 
 * ``shared`` — applied on top of ``base``. Rewrites
-  ``component("pdfium")`` to ``shared_library("pdfium")`` in BUILD.gn
-  so a second ninja pass yields ``libpdfium.so``.
+  ``static_library("pdfium")`` to ``shared_library("pdfium")`` in
+  BUILD.gn so a second ninja pass yields ``libpdfium.so``.
 
 All patches match bblanchon/pdfium-binaries (patches/musl/).
 
@@ -34,13 +36,26 @@ import sys
 from pathlib import Path
 
 
-def patch_build_gn(pdfium_dir: Path) -> None:
-    """Patch BUILD.gn: component() -> shared_library()."""
+def patch_build_gn_static(pdfium_dir: Path) -> None:
+    """Patch BUILD.gn: component() -> static_library()."""
     build_gn = pdfium_dir / "BUILD.gn"
     text = build_gn.read_text()
-    updated = text.replace('component("pdfium")', 'shared_library("pdfium")')
+    updated = text.replace('component("pdfium")', 'static_library("pdfium")')
     if updated == text:
         print('WARNING: component("pdfium") not found in BUILD.gn — already patched?')
+        return
+    build_gn.write_text(updated)
+    print("Applied: BUILD.gn -> static_library")
+
+
+def patch_build_gn_shared(pdfium_dir: Path) -> None:
+    """Patch BUILD.gn: component()/static_library() -> shared_library()."""
+    build_gn = pdfium_dir / "BUILD.gn"
+    text = build_gn.read_text()
+    updated = text.replace('static_library("pdfium")', 'shared_library("pdfium")')
+    updated = updated.replace('component("pdfium")', 'shared_library("pdfium")')
+    if updated == text:
+        print('WARNING: no pdfium target to rewrite in BUILD.gn — already patched?')
         return
     build_gn.write_text(updated)
     print("Applied: BUILD.gn -> shared_library")
@@ -248,9 +263,9 @@ def main() -> None:
         choices=["base", "shared", "all"],
         default="all",
         help=(
-            "base = everything except BUILD.gn component->shared rewrite "
-            "(produces libpdfium.a); shared = adds the BUILD.gn rewrite "
-            "(produces libpdfium.so); all = both (default, legacy behavior)."
+            "base = rewrite component() to static_library + musl toolchain/"
+            "config setup (produces libpdfium.a); shared = rewrite target "
+            "to shared_library (produces libpdfium.so); all = both (default)."
         ),
     )
     args = parser.parse_args()
@@ -265,8 +280,9 @@ def main() -> None:
         patch_buildconfig_gn(pdfium_dir)
         patch_highway_build_gn(pdfium_dir)
         install_musl_toolchain(pdfium_dir)
+        patch_build_gn_static(pdfium_dir)
     if args.mode in ("shared", "all"):
-        patch_build_gn(pdfium_dir)
+        patch_build_gn_shared(pdfium_dir)
 
 
 if __name__ == "__main__":

--- a/pdfium/tests/test_resolve_jobs.py
+++ b/pdfium/tests/test_resolve_jobs.py
@@ -8,14 +8,17 @@ class TestDefaultMatrix:
     def test_no_flags_returns_default(self):
         assert resolve_jobs(None, None) == list(DEFAULT_JOBS)
 
-    def test_default_is_five_jobs(self):
-        assert len(DEFAULT_JOBS) == 5
+    def test_default_is_four_jobs(self):
+        # mac was removed from the default matrix because PDFium's GN
+        # config invokes xcodebuild during `gn gen`, which doesn't exist
+        # in a Debian container — mac builds require a macOS host.
+        assert len(DEFAULT_JOBS) == 4
 
     def test_default_excludes_mac_amd64(self):
         assert ("mac", "amd64") not in DEFAULT_JOBS
 
-    def test_default_includes_mac_arm64(self):
-        assert ("mac", "arm64") in DEFAULT_JOBS
+    def test_default_excludes_mac_arm64(self):
+        assert ("mac", "arm64") not in DEFAULT_JOBS
 
 
 class TestPlatformFilter:
@@ -27,9 +30,12 @@ class TestPlatformFilter:
         jobs = resolve_jobs(["musl"], None)
         assert jobs == [("musl", "amd64"), ("musl", "arm64")]
 
-    def test_platform_mac_only_gives_arm64_by_default(self):
+    def test_platform_mac_falls_back_to_both_archs(self):
+        # mac is not in the default matrix, so resolve_jobs hits the
+        # ``missing`` branch that cross-products the requested platform
+        # with both archs.
         jobs = resolve_jobs(["mac"], None)
-        assert jobs == [("mac", "arm64")]
+        assert jobs == [("mac", "amd64"), ("mac", "arm64")]
 
     def test_platform_linux_musl_both(self):
         jobs = resolve_jobs(["linux", "musl"], None)
@@ -47,9 +53,10 @@ class TestArchFilter:
         assert jobs == [("linux", "amd64"), ("musl", "amd64")]
         assert ("mac", "amd64") not in jobs
 
-    def test_arch_arm64_includes_mac(self):
+    def test_arch_arm64_excludes_mac(self):
+        # mac not in DEFAULT_JOBS, so filtering by arch never surfaces it.
         jobs = resolve_jobs(None, "arm64")
-        assert jobs == [("linux", "arm64"), ("mac", "arm64"), ("musl", "arm64")]
+        assert jobs == [("linux", "arm64"), ("musl", "arm64")]
 
 
 class TestBothFlags:


### PR DESCRIPTION
## Summary

Fixes multiple issues surfaced by recent `--parallel --upload` runs and
adds an interactive cancel feature.

### Fixes

- **`libpdfium.a` was never produced.** `patches/{linux,musl}.py` base
  mode left `BUILD.gn` unchanged on the assumption that
  `component("pdfium")` resolves to `static_library` under
  `is_component_build=false`. It actually resolves to `source_set`,
  which groups objects without linking an archive. Base mode now
  rewrites the target to `static_library("pdfium")` explicitly; shared
  mode accepts either form so the two can compose.
- **Verify/staging paths were wrong.** GN's `static_library` emits the
  archive at `obj/<package>/lib<name>.a`, not at the ninja out-dir
  root. The Dockerfile's `ls`/`file`/`cp` commands now look at
  `out/Static/obj/libpdfium.a`.
- **Transient network flakes.** Wrap `git clone depot_tools` in a 5×
  retry loop (10 s backoff), add `--retry 5 --retry-delay 10
  --retry-all-errors` to the `musl.cc` curl, and pre-warm gsutil
  before `gclient sync` so parallel workers don't race on the flock
  (`lockfile.LockError: Errno 11 EAGAIN`).
- **`--upload` destroyed partial progress.** Replaced the
  delete-and-recreate with append/clobber: `gh release upload
  --clobber` preserves assets whose names aren't being rebuilt, so a
  `--platform musl` re-run no longer removes the `pdfium-linux-*`
  archives from the release.
- **`mac` removed from `DEFAULT_JOBS`.** PDFium's GN config calls
  `xcodebuild` during `gn gen`, which doesn't exist in a Debian
  container. `bblanchon/pdfium-binaries` runs mac builds on
  `macos-15` runners rather than cross-compiling from Linux —
  we follow the same pattern. The mac Dockerfile generator remains
  for users who provision an Xcode SDK themselves.

### New feature

Interactive cancellation:

- `c` — cancel the currently-viewed job
- `q` or `C` — cancel every job, including queued ones
- Cancelled jobs render as `⊘ cancelled` (distinct from `✗ failed`)
- Jobs held by the memory scheduler bail immediately if `cancel_all`
  fired before their turn

### Docs

`README.md` and `MANUAL.md` updated to reflect the 4-archive matrix,
the new keybindings, the append/replace `--upload` semantics, and
troubleshooting entries for every failure mode fixed in this PR.

## Test plan

- [x] `patches/linux.py` and `patches/musl.py` unit-tested via a
      round-trip on a synthetic `BUILD.gn` (`component` → `static_library`
      → `shared_library`).
- [ ] Full `python3 pdfium/build_pdfium.py 7725 --parallel --upload`
      produces 4 archives and uploads them to `pdfium-7725`.
- [ ] `libpdfium.a` present and non-empty in each archive's `lib/`.
- [ ] Re-run `--platform musl --upload` leaves `pdfium-linux-*` assets
      on the release untouched.
- [ ] `c` and `q` keypresses cancel jobs as expected in `--parallel`.