### PR TITLE
fix(pdfium): non-empty static archive, musl arm64 sysroot, partial upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 pdfium/bin/
+/bin/
 __pycache__/
 .pytest_cache/
 *.o

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -156,15 +156,22 @@ container's own CPU arch, not the target.
 
 **`--upload`**
 
-:   After a successful build, publish the archives as assets on the
-    GitHub Release tagged `pdfium-{VERSION}` on
-    `libviprs/libviprs-dep`. If the release does not exist it is
-    created; if it already exists, assets whose filenames match
-    something newly built are **replaced** (via
+:   Publish archives as assets on the GitHub Release tagged
+    `pdfium-{VERSION}` on `libviprs/libviprs-dep`. If the release does
+    not exist it is created; if it already exists, assets whose
+    filenames match something newly built are **replaced** (via
     `gh release upload --clobber`) and any unrelated assets are
     **preserved**. This lets a partial re-run — e.g.
     `--platform musl --upload` after fixing a musl-only regression —
     update only the musl tarballs without touching the linux ones.
+
+    The upload runs with **whatever archives successfully built**, even
+    when other jobs in the same matrix failed. A flake on one arch
+    therefore doesn't waste the 30-minute successful builds of the
+    others; the good archives are published and the script exits `1`
+    with a per-job failure summary so CI still treats the run as
+    broken. If zero archives built, the upload is skipped entirely.
+
     Requires `gh` to be installed and authenticated (`gh auth login`).
 
 **`--output-dir DIR`**
@@ -280,8 +287,8 @@ prefix.
 
 | Code | Meaning |
 | --- | --- |
-| `0` | All requested builds completed and, if `--upload` was passed, the release was created. |
-| `1` | A dependency check failed, a Docker build failed, or the `gh release create` call failed. |
+| `0` | Every requested build completed and, if `--upload` was passed, the release was created/updated. |
+| `1` | At least one build failed, or a dependency check / `gh release` call failed. With `--upload`, archives from builds that *did* succeed are still uploaded before the script exits `1`; stderr lists which jobs failed and where their logs live. |
 | `130` | Interrupted (SIGINT / Ctrl-C). |
 
 ## EXAMPLES
@@ -330,7 +337,8 @@ python3 pdfium/build_pdfium.py 7725 --upload
 Creates the `pdfium-7725` GitHub Release (if missing) and attaches all
 four archives. If the release already exists, its assets are appended
 or replaced in place — any unrelated assets on the release are
-preserved.
+preserved. If one arch fails, the other three are still uploaded and
+the script exits `1` with a failure summary.
 
 ### Re-run one platform and update only its assets
 
@@ -457,6 +465,31 @@ hand and see this error, update both the verify step
 (`ls -lh out/Static/obj/libpdfium.a`) and the staging copy
 (`cp out/Static/obj/libpdfium.a /staging/lib/`) to the `obj/` path.
 
+### `libpdfium.a` is 8 bytes (empty `ar` archive)
+
+GN's `static_library` only archives objects the target *directly*
+owns; PDFium's `pdfium` target is an umbrella with many `deps` and
+almost no direct `sources`, so a naive `component() → static_library`
+rewrite produces an archive containing just the `!<arch>\n` magic
+header. The base-mode patches now insert `complete_static_lib = true`
+into the rewritten target, which tells GN to pull every transitive
+dependency's objects into the archive. If you forked the patches,
+make sure that flag is present on the static target. The shared-mode
+patch strips the flag before rewriting to `shared_library` because
+GN rejects `complete_static_lib` on non-static targets.
+
+### `ERROR at //build/config/sysroot.gni:60:7: Assertion failed` (musl)
+
+GN asserts `path_exists(sysroot)` resolves to an existing directory,
+but the musl Dockerfile deliberately skips
+`build/linux/sysroot_scripts/install-sysroot.py` — the musl build uses
+the sysroot bundled with musl-cross-make, not the Debian sysroot. The
+musl GN args now include `use_sysroot = false` to tell Chromium's
+build config to skip the Debian sysroot lookup entirely. Affects
+`musl/arm64` in particular, because Chromium only auto-downloads the
+amd64 sysroot via hooks; arm64 requires the explicit install step
+that musl skips.
+
 ### `FileNotFoundError: No such file or directory: 'xcodebuild'` during `gn gen`
 
 You attempted `--platform mac` on a Linux host. PDFium's
@@ -506,7 +539,7 @@ parallel matrix.
 
 ## HISTORY
 
-- **pdfium-7725** (2026-04) — first release to ship both `libpdfium.so` and `libpdfium.a` per archive, and to include musl-linked variants (`pdfium-musl-x64.tgz`, `pdfium-musl-arm64.tgz`) in the default matrix. Interactive cancellation (`c` / `q`), retry-wrapped network steps, and `--upload` append/replace semantics landed in the same cycle. `mac` was removed from the default matrix after bblanchon/pdfium-binaries confirmed that mac builds require a macOS host.
+- **pdfium-7725** (2026-04) — first release to ship both `libpdfium.so` and `libpdfium.a` per archive, and to include musl-linked variants (`pdfium-musl-x64.tgz`, `pdfium-musl-arm64.tgz`) in the default matrix. Interactive cancellation (`c` / `q`), retry-wrapped network steps, `--upload` append/replace semantics, partial-failure uploads, `complete_static_lib = true` for a non-empty `libpdfium.a`, and `use_sysroot = false` for musl all landed in the same cycle. `mac` was removed from the default matrix after bblanchon/pdfium-binaries confirmed that mac builds require a macOS host.
 - **pdfium earlier** — glibc-only shared library releases.
 
 ## LICENSE

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ While the build is running, the terminal header accepts these keys:
 
 Every job streams its full Docker build output to `pdfium/bin/logs/<plat>-<arch>.log`. If a job fails, the script prints the log path to stderr — `tail -n 200 pdfium/bin/logs/linux-arm64.log` gives you the authoritative post-mortem, since the in-terminal view only retains the last ~500 lines per job.
 
+Partial failures don't lose the run. When `--upload` is passed, the archives from builds that *did* succeed are still attached to the GitHub Release (via `gh release upload --clobber`) before the script exits `1` with a per-job failure summary — so one flake never wastes a 30-minute successful build of the other three archives.
+
 Or trigger the **Build PDFium** GitHub Actions workflow via `workflow_dispatch`, entering the chromium branch number and toggling `upload=true`.
 
 ## Development

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -164,7 +164,13 @@ GN_ARGS_PLATFORM = {
         "is_clang = false\n"
         "use_custom_libcxx = false\n"
         "use_custom_libcxx_for_host = false\n"
-        "use_glib = false"
+        "use_glib = false\n"
+        # musl-cross-make ships its own sysroot per target triple, so
+        # pointing Chromium at the hermetic Debian sysroot
+        # (build/linux/debian_bullseye_<arch>-sysroot) is both wrong
+        # and — for arm64 — outright fatal because the musl Dockerfile
+        # skips install-sysroot.py.
+        "use_sysroot = false"
     ),
 }
 
@@ -1738,6 +1744,11 @@ def main():
         )
 
     built_files = []
+    # Collect failures per-job instead of letting the first exception kill
+    # the whole run. A flake on one arch shouldn't waste a 30-minute
+    # successful build of the other three — upload_release already handles
+    # partial sets (append/--clobber, leaves unrelated assets intact).
+    failures = []  # list of (job, exception)
     try:
         progress = BuildProgress(args.version, job_ids, parallel=args.parallel)
         try:
@@ -1757,33 +1768,58 @@ def main():
                         for plat, arch in jobs
                     }
                     for future in concurrent.futures.as_completed(futures):
-                        built_files.append(future.result())
+                        plat, arch = futures[future]
+                        job_id = f"{plat}/{arch}"
+                        try:
+                            built_files.append(future.result())
+                        except (RuntimeError, subprocess.CalledProcessError) as e:
+                            failures.append((job_id, e))
             else:
                 for plat, arch in jobs:
-                    path = build_for_arch(args.version, arch, plat, output_dir, progress)
-                    built_files.append(path)
+                    job_id = f"{plat}/{arch}"
+                    try:
+                        path = build_for_arch(args.version, arch, plat, output_dir, progress)
+                        built_files.append(path)
+                    except (RuntimeError, subprocess.CalledProcessError) as e:
+                        failures.append((job_id, e))
         finally:
             progress.finish()
 
         # Sort so upload order is deterministic regardless of parallel completion order.
         built_files.sort()
 
-        if args.upload:
-            # Reuse a lightweight progress instance just to show the "Uploading..."
-            # banner during the gh release create; no job work runs here.
+        # Upload whatever succeeded. Skipping upload entirely on partial
+        # failure would waste the successful archives; upload_release uses
+        # --clobber so matching-name assets on the release are replaced
+        # and unrelated ones are preserved.
+        if args.upload and built_files:
             upload_progress = BuildProgress(args.version, job_ids, parallel=False)
             try:
                 upload_release(args.version, built_files, upload_progress)
             finally:
                 upload_progress.finish()
-    except (RuntimeError, subprocess.CalledProcessError) as e:
-        print(f"\nError: {e}", file=sys.stderr)
-        log_dir = os.path.join(output_dir, "logs")
-        print(f"Per-job build logs: {log_dir}/", file=sys.stderr)
-        sys.exit(1)
+        elif args.upload and not built_files:
+            print("\nNo archives built — skipping upload.", file=sys.stderr)
     except KeyboardInterrupt:
         print("\nInterrupted.", file=sys.stderr)
         sys.exit(130)
+
+    if failures:
+        log_dir = os.path.join(output_dir, "logs")
+        print(
+            f"\n{len(failures)} of {len(jobs)} builds failed:",
+            file=sys.stderr,
+        )
+        for job_id, exc in failures:
+            print(f"  - {job_id}: {exc}", file=sys.stderr)
+        print(f"Per-job build logs: {log_dir}/", file=sys.stderr)
+        if built_files:
+            print(
+                f"Uploaded {len(built_files)} successful archive"
+                f"{'s' if len(built_files) != 1 else ''} to the release.",
+                file=sys.stderr,
+            )
+        sys.exit(1)
 
     print(f"\nBuilt {len(built_files)} binaries in {output_dir}/")
 

--- a/pdfium/patches/linux.py
+++ b/pdfium/patches/linux.py
@@ -36,15 +36,28 @@ from pathlib import Path
 
 
 def patch_build_gn_static(pdfium_dir: Path) -> None:
-    """Patch BUILD.gn: component() -> static_library()."""
+    """Patch BUILD.gn: component() -> static_library() + complete_static_lib.
+
+    Just renaming ``component("pdfium")`` to ``static_library("pdfium")``
+    produces an 8-byte ar archive (magic header only) because PDFium's
+    ``pdfium`` target has many ``deps`` but almost no direct ``sources``
+    — GN's default ``static_library`` only archives objects the target
+    owns directly, not those pulled in via deps. ``complete_static_lib
+    = true`` tells GN to include every transitive dependency's objects
+    in the archive, producing a self-contained ``libpdfium.a`` that can
+    be linked without re-resolving all of PDFium's third-party deps.
+    """
     build_gn = pdfium_dir / "BUILD.gn"
     text = build_gn.read_text()
-    updated = text.replace('component("pdfium")', 'static_library("pdfium")')
+    updated = text.replace(
+        'component("pdfium") {',
+        'static_library("pdfium") {\n  complete_static_lib = true',
+    )
     if updated == text:
-        print('WARNING: component("pdfium") not found in BUILD.gn — already patched?')
+        print('WARNING: component("pdfium") { not found in BUILD.gn — already patched?')
         return
     build_gn.write_text(updated)
-    print("Applied: BUILD.gn -> static_library")
+    print("Applied: BUILD.gn -> static_library (complete_static_lib)")
 
 
 def patch_build_gn_shared(pdfium_dir: Path) -> None:
@@ -52,12 +65,18 @@ def patch_build_gn_shared(pdfium_dir: Path) -> None:
 
     Handles both the pristine ``component("pdfium")`` form and the
     post-``base``-mode ``static_library("pdfium")`` form, so ``shared``
-    works whether or not ``base`` ran first.
+    works whether or not ``base`` ran first. Also strips the
+    ``complete_static_lib = true`` line that ``base`` inserts —
+    ``complete_static_lib`` is only valid on static_library targets and
+    GN errors out if it appears inside a shared_library.
     """
     build_gn = pdfium_dir / "BUILD.gn"
     text = build_gn.read_text()
     updated = text.replace('static_library("pdfium")', 'shared_library("pdfium")')
     updated = updated.replace('component("pdfium")', 'shared_library("pdfium")')
+    # Drop the complete_static_lib line that the base patch added; it's
+    # only valid in a static_library target.
+    updated = re.sub(r"\n\s*complete_static_lib = true\s*\n", "\n", updated)
     if updated == text:
         print("WARNING: no pdfium target to rewrite in BUILD.gn — already patched?")
         return

--- a/pdfium/patches/musl.py
+++ b/pdfium/patches/musl.py
@@ -37,23 +37,36 @@ from pathlib import Path
 
 
 def patch_build_gn_static(pdfium_dir: Path) -> None:
-    """Patch BUILD.gn: component() -> static_library()."""
+    """Patch BUILD.gn: component() -> static_library() + complete_static_lib.
+
+    See ``linux.py``'s docstring for why ``complete_static_lib = true``
+    is required: PDFium's ``pdfium`` target is an umbrella with deps but
+    no direct sources, so without this flag the archive is empty.
+    """
     build_gn = pdfium_dir / "BUILD.gn"
     text = build_gn.read_text()
-    updated = text.replace('component("pdfium")', 'static_library("pdfium")')
+    updated = text.replace(
+        'component("pdfium") {',
+        'static_library("pdfium") {\n  complete_static_lib = true',
+    )
     if updated == text:
-        print('WARNING: component("pdfium") not found in BUILD.gn — already patched?')
+        print('WARNING: component("pdfium") { not found in BUILD.gn — already patched?')
         return
     build_gn.write_text(updated)
-    print("Applied: BUILD.gn -> static_library")
+    print("Applied: BUILD.gn -> static_library (complete_static_lib)")
 
 
 def patch_build_gn_shared(pdfium_dir: Path) -> None:
-    """Patch BUILD.gn: component()/static_library() -> shared_library()."""
+    """Patch BUILD.gn: component()/static_library() -> shared_library().
+
+    Also strips the ``complete_static_lib = true`` line the base patch
+    adds, since that flag is only valid on static_library targets.
+    """
     build_gn = pdfium_dir / "BUILD.gn"
     text = build_gn.read_text()
     updated = text.replace('static_library("pdfium")', 'shared_library("pdfium")')
     updated = updated.replace('component("pdfium")', 'shared_library("pdfium")')
+    updated = re.sub(r"\n\s*complete_static_lib = true\s*\n", "\n", updated)
     if updated == text:
         print("WARNING: no pdfium target to rewrite in BUILD.gn — already patched?")
         return


### PR DESCRIPTION
## Summary

Three related fixes surfaced by the last `--parallel --upload` run:

### 1. `libpdfium.a` was 8 bytes (empty `ar` archive)

GN's `static_library` only archives the target's *direct* object
files. PDFium's `pdfium` target is an umbrella with many `deps` but
almost no direct `sources`, so our `component() → static_library`
rewrite produced an archive containing only the `!<arch>\n` magic
header. The base-mode patches in `patches/{linux,musl}.py` now inject
`complete_static_lib = true` into the rewritten target so every
transitive dep's objects are included. The shared-mode patch strips
the flag before rewriting to `shared_library` — GN rejects
`complete_static_lib` on non-static targets.

### 2. `musl/arm64` failed at `gn gen` with a sysroot assertion

```
ERROR at //build/config/sysroot.gni:60:7: Assertion failed.
Missing sysroot (//build/linux/debian_bullseye_arm64-sysroot).
```

The musl Dockerfile deliberately skips `install-sysroot.py` because
musl builds use the sysroot bundled with musl-cross-make. Chromium's
GN config still asserts `path_exists(sysroot)` unless explicitly told
to skip it, and only auto-downloads the amd64 sysroot via hooks (not
arm64) — so `musl/amd64` slipped by while `musl/arm64` broke. Fix:
add `use_sysroot = false` to the musl GN args.

### 3. One flake killed the whole run's upload

`concurrent.futures.as_completed` re-raised the first failed future's
exception, which propagated past the `if args.upload:` block. A
30-minute successful build of three archives was being thrown away
because a fourth flaked.

`main()` now:

- Collects per-job exceptions into a `failures` list instead of
  re-raising
- Runs `upload_release()` on whatever archives did build (if any)
- Prints a per-job failure summary on stderr with the log path
- Exits `1` when any job failed so CI still treats the run as broken

`upload_release` already supports partial sets via `--clobber` +
preserving unrelated assets, so the existing upload path was already
correct — only the gating in `main()` needed to change.

### Docs

- `MANUAL.md`: rewrite `--upload` + `EXIT STATUS` to describe the
  partial-upload semantics; new troubleshooting entries for the
  empty-archive and musl sysroot failures.
- `README.md`: one-line note about partial-failure uploads.
- `.gitignore`: add `/bin/` (top-level output directory created when
  running from the repo root) alongside the existing `pdfium/bin/`.

## Test plan

- [x] Patch round-trip unit test: `component("pdfium") { ... }` →
      `static_library("pdfium") { complete_static_lib = true ... }`
      → `shared_library("pdfium") { ... }` with `complete_static_lib`
      stripped.
- [x] `pytest pdfium/tests/` — 98 tests pass locally.
- [x] `ruff format --check` and `ruff check` clean.
- [ ] End-to-end: `python3 pdfium/build_pdfium.py 7725 --parallel
      --upload` yields a non-empty `libpdfium.a` in every archive and
      a completed `pdfium-7725` release.
- [ ] Inject a deliberate failure on one arch; confirm the other
      three archives upload, the failing one is listed on stderr,
      and the process exits `1`.