### PR TITLE
fix(pdfium): cap gclient sync --jobs=8 to prevent DNS saturation

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -518,6 +518,27 @@ for `musl.cc`). If all retries fail, check the Docker VM's DNS
 configuration (`docker info | grep -i dns`) or drop parallelism for
 the affected run.
 
+### Repeated `subprocess ... git fetch ... failed; will retry after a short nap` from gclient, or `read udp ... i/o timeout` looking up `storage.googleapis.com`
+
+These are not rate-limits from Google — Google's infrastructure
+handles this traffic trivially. The bottleneck is Docker Desktop's
+built-in DNS forwarder (typically at `192.168.65.7:53`), which is a
+minimal userspace resolver not designed for hundreds of concurrent
+lookups. `gclient sync` defaults its worker pool to `cpu_count()` —
+on a 28-core host, four parallel containers × 28 workers = ~112
+simultaneous git fetches + DNS queries per container, which
+saturates the forwarder.
+
+The Dockerfiles cap per-container parallelism with
+`gclient sync ... --jobs=8`, putting the full matrix at ~32
+concurrent requests — well within any DNS resolver's capacity. If
+you still see timeouts, either:
+
+- **Give the Docker daemon a real DNS resolver**: Docker Desktop →
+  Settings → Resources → Network → set DNS to `8.8.8.8, 1.1.1.1`.
+- **Lower the matrix's parallelism**: drop `--parallel`, or re-run
+  with `--platform linux` then `--platform musl` sequentially.
+
 ### Docker build fails with `rpc error: code = Unavailable ... EOF`
 
 The BuildKit daemon inside the Docker VM disconnected mid-build —
@@ -539,7 +560,7 @@ parallel matrix.
 
 ## HISTORY
 
-- **pdfium-7725** (2026-04) — first release to ship both `libpdfium.so` and `libpdfium.a` per archive, and to include musl-linked variants (`pdfium-musl-x64.tgz`, `pdfium-musl-arm64.tgz`) in the default matrix. Interactive cancellation (`c` / `q`), retry-wrapped network steps, `--upload` append/replace semantics, partial-failure uploads, `complete_static_lib = true` for a non-empty `libpdfium.a`, and `use_sysroot = false` for musl all landed in the same cycle. `mac` was removed from the default matrix after bblanchon/pdfium-binaries confirmed that mac builds require a macOS host.
+- **pdfium-7725** (2026-04) — first release to ship both `libpdfium.so` and `libpdfium.a` per archive, and to include musl-linked variants (`pdfium-musl-x64.tgz`, `pdfium-musl-arm64.tgz`) in the default matrix. Interactive cancellation (`c` / `q`), retry-wrapped network steps, `--upload` append/replace semantics, partial-failure uploads, `complete_static_lib = true` for a non-empty `libpdfium.a`, `use_sysroot = false` for musl, and `gclient sync --jobs=8` to stop saturating Docker Desktop's DNS forwarder all landed in the same cycle. `mac` was removed from the default matrix after bblanchon/pdfium-binaries confirmed that mac builds require a macOS host.
 - **pdfium earlier** — glibc-only shared library releases.
 
 ## LICENSE

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Build the full default matrix for chromium branch 7725 and publish it as a relea
 python3 pdfium/build_pdfium.py 7725 --parallel --upload
 ```
 
-`--parallel` fans out every `(platform, arch)` combo (4 by default) at once, gated by a memory scheduler that reads the Docker daemon's `MemTotal` and queues over-budget combos until earlier ones finish. Tune with `--mem-per-build MB` (default `4096`) if you see builds queuing unnecessarily on a large host or want extra safety margin on a small one.
+`--parallel` fans out every `(platform, arch)` combo (4 by default) at once, gated by a memory scheduler that reads the Docker daemon's `MemTotal` and queues over-budget combos until earlier ones finish. Tune with `--mem-per-build MB` (default `4096`) if you see builds queuing unnecessarily on a large host or want extra safety margin on a small one. Each container caps its internal `gclient sync` worker pool at 8 so four concurrent builds stay under Docker Desktop's DNS forwarder limits (see `MANUAL.md` troubleshooting for details).
 
 While the build is running, the terminal header accepts these keys:
 

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -1078,8 +1078,14 @@ RUN gclient config --unmanaged https://pdfium.googlesource.com/pdfium.git \\
     --custom-var "checkout_configuration=small"
 RUN echo "target_os = [ '{plat}' ]" >> .gclient
 
-# Step 3: Checkout source at target branch
-RUN gclient sync -r "origin/{branch}" --no-history --shallow
+# Step 3: Checkout source at target branch.
+# gclient's default --jobs is cpu_count(), which on a 28-core host
+# means each container spawns 28 parallel git fetches + DNS lookups;
+# four concurrent containers multiply that into ~112 in-flight fetches,
+# overwhelming Docker Desktop's built-in DNS forwarder (look for
+# "read udp ... i/o timeout" errors). --jobs=8 caps the fan-out so the
+# total across the default matrix stays under ~32 concurrent requests.
+RUN gclient sync -r "origin/{branch}" --no-history --shallow --jobs=8
 
 # Step 4: Build dependencies and sysroot
 WORKDIR /build/pdfium
@@ -1173,7 +1179,8 @@ RUN gclient config --unmanaged https://pdfium.googlesource.com/pdfium.git \\
 RUN echo "target_os = [ 'mac' ]" >> .gclient
 
 # Step 3: Checkout source at target branch
-RUN gclient sync -r "origin/{branch}" --no-history --shallow
+# See linux Dockerfile for why --jobs=8 (DNS saturation under default).
+RUN gclient sync -r "origin/{branch}" --no-history --shallow --jobs=8
 
 # Step 4: Build dependencies
 WORKDIR /build/pdfium
@@ -1258,8 +1265,9 @@ RUN gclient config --unmanaged https://pdfium.googlesource.com/pdfium.git \\
     --custom-var "checkout_configuration=small"
 RUN echo "target_os = [ 'linux' ]" >> .gclient
 
-# Step 4: Checkout source at target branch
-RUN gclient sync -r "origin/{branch}" --no-history --shallow
+# Step 4: Checkout source at target branch.
+# See linux Dockerfile for why --jobs=8 (DNS saturation under default).
+RUN gclient sync -r "origin/{branch}" --no-history --shallow --jobs=8
 
 # Step 5: Build dependencies
 WORKDIR /build/pdfium


### PR DESCRIPTION
## Summary

During `--parallel` runs we were seeing repeated `subprocess ... git
fetch ... failed; will retry after a short nap` warnings from
gclient, and eventually `read udp ... i/o timeout` DNS errors for
`chromium.googlesource.com` and `storage.googleapis.com`.

The upstream services are fine — Google absorbs this volume without
blinking. The bottleneck is **Docker Desktop's built-in DNS
forwarder** (typically `192.168.65.7:53`), a minimal userspace
resolver that isn't designed for hundreds of concurrent lookups.

### Why we were overwhelming it

`gclient sync` defaults its worker pool to `cpu_count()`. On the
28-core dev host used here, that's **28 parallel git fetches + DNS
lookups per container**. With four containers running concurrently
under `--parallel`, the matrix produces ~112 simultaneous lookups
from a single client. The forwarder drops packets, gclient retries,
and the log fills with retry warnings.

### Fix

Pin `--jobs=8` on every `gclient sync` (`_make_dockerfile_linux`,
`_make_dockerfile_mac`, `_make_dockerfile_musl`). Four concurrent
containers × 8 workers = ~32 simultaneous requests — well within
any DNS resolver's capacity. Trade-off: per-container sync is a
little slower, but total wall time usually wins back more than it
loses because we stop burning 3×-retry cycles per fetch.

Full explanatory comment lives in the linux Dockerfile; mac and
musl cross-reference it to avoid repetition.

### Docs

- `MANUAL.md`: new troubleshooting entry for the DNS saturation
  pattern, explaining both the `--jobs=8` cap and the
  heavier-hammer option of reconfiguring Docker Desktop's DNS
  (`Settings → Resources → Network → 8.8.8.8, 1.1.1.1`).
- `README.md`: one-line note about the per-container `--jobs=8` cap.
- HISTORY row updated.

## Test plan

- [x] `pytest pdfium/tests/` — 98 tests pass.
- [x] `ruff format --check` + `ruff check` — clean.
- [ ] End-to-end: `python3 pdfium/build_pdfium.py 7725 --parallel
      --upload` completes without the repeated gclient retry
      warnings and without DNS timeout errors.