### PR TITLE
fix(pdfium): strictly verify libpdfium.a is a complete fat archive

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -44,15 +44,23 @@ Docker, Python, and (for uploads) the `gh` CLI. For each requested
 1. Generates a platform-specific Dockerfile on the fly.
 2. Builds an amd64 Docker image that runs the full compile inside the
    container.
-3. Applies the **base** platform patch (symbol-visibility fixes, plus
-   musl-specific toolchain setup where applicable) and runs `ninja`
-   against `out/Static`, producing `libpdfium.a`.
+3. Applies the **base** platform patch (symbol-visibility fixes, the
+   `component("pdfium")` → `static_library("pdfium") {
+   complete_static_lib = true }` rewrite, plus musl-specific toolchain
+   setup where applicable) and runs `ninja` against `out/Static`,
+   producing a complete (fat) `libpdfium.a`.
 4. Applies the **shared** patch on top (rewrites
-   `component("pdfium")` → `shared_library("pdfium")`) and runs `ninja`
-   against `out/Shared`, producing `libpdfium.so`.
-5. Stages both artifacts — along with the public C headers, the two
+   `static_library("pdfium")` → `shared_library("pdfium")` and strips
+   the static-only `complete_static_lib` line) and runs `ninja` against
+   `out/Shared`, producing `libpdfium.so`.
+5. **Verifies** `libpdfium.a`: archive magic must be `!<arch>\n` (not
+   `!<thin>\n`), archive must have ≥ 100 members and be ≥ 10 MB. Thin
+   archives reference `.o` paths inside the build sandbox and would
+   fail to link once extracted, so the Docker build fails here rather
+   than publish a broken archive.
+6. Stages both artifacts — along with the public C headers, the two
    `args.gn` files, and `LICENSE` — into a single directory.
-6. Extracts the staging directory from the container and packages it as
+7. Extracts the staging directory from the container and packages it as
    `pdfium-{platform}-{gn_cpu}.tgz` in the output directory.
 
 The two-phase ninja build is the cleanest way to emit both a static
@@ -449,6 +457,17 @@ directory containing it.
 You are using `libpdfium.a` from an older release that predates the
 `FPDF_EXPORT` visibility patch. Upgrade to `pdfium-7725` or newer. The
 visibility patch is applied unconditionally under `--mode base`.
+
+### `libpdfium.a: archive has no index; run ranlib to add one` (or tiny `.a`)
+
+You're using a `libpdfium.a` from an early release that shipped a GNU
+thin archive — it only stored `.o` path references, not the object
+code, so once the Docker build sandbox was gone the archive was
+unlinkable. Upgrade to a release built after the `complete_static_lib`
+fix; the first 8 bytes of the archive must read `!<arch>\n`, never
+`!<thin>\n`. Current releases enforce this during the Docker build
+(archive magic + `ar t` member count + size floor) and will fail the
+build rather than publish a broken archive.
 
 ### Docker buildkit steps fail with "no space left on device"
 

--- a/pdfium/README.md
+++ b/pdfium/README.md
@@ -81,11 +81,11 @@ The build pipeline (inspired by [bblanchon/pdfium-binaries](https://github.com/b
 2. Configure gclient with `checkout_configuration=small` (skips V8, test deps, cipd)
 3. Checkout PDFium source at the target chromium branch
 4. Install build dependencies and target architecture sysroot (linux) or musl-cross-make toolchain (musl)
-5. Apply the **base** platform patch — symbol visibility, musl toolchain GN config where relevant. Leaves `BUILD.gn` alone so `component("pdfium")` resolves to `static_library` under `is_component_build=false`.
+5. Apply the **base** platform patch — symbol visibility, rewrite `component("pdfium")` to `static_library("pdfium")` with `complete_static_lib = true`, plus musl toolchain GN config where relevant. Chromium's `component()` template resolves to `source_set` (not `static_library`) under `is_component_build=false`, so the explicit `static_library` rewrite is what actually gets a `.a` emitted; `complete_static_lib = true` then forces it to be a fat archive containing every transitive object.
 6. `gn gen out/Static` + `ninja -C out/Static pdfium` — produces `libpdfium.a`
-7. Apply the **shared** platform patch — rewrites `component("pdfium")` to `shared_library("pdfium")`.
+7. Apply the **shared** platform patch — rewrites `static_library("pdfium")` to `shared_library("pdfium")` and strips the static-only `complete_static_lib` line.
 8. `gn gen out/Shared` + `ninja -C out/Shared pdfium` — produces `libpdfium.so`
-9. Verify both outputs
+9. **Verify** `libpdfium.a` is a complete fat archive: magic must be `!<arch>\n` (not `!<thin>\n`), archive must have ≥ 100 members and be ≥ 10 MB. A thin archive would reference `.o` files in the now-discarded build sandbox, so the build fails here rather than publish a broken archive.
 10. Stage artifacts into a single directory and package as `pdfium-{platform}-{gn_cpu}.tgz`
 
 The two-phase ninja build is the cleanest way to emit both a static archive and a shared library from a single source checkout without duplicating the `component("pdfium")` target body inside `BUILD.gn`. It roughly doubles the ninja time per combo, but the expensive Docker setup steps (apt, depot_tools, gclient sync, runhooks) only run once per combo.

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -1028,6 +1028,39 @@ def make_dockerfile(version, arch, plat):
     return _make_dockerfile_linux(version, arch, plat)
 
 
+# Strict verification that ``out/Static/obj/libpdfium.a`` is a complete
+# (fat) static archive before we stage it. The base-mode patch rewrites
+# ``component("pdfium")`` to ``static_library("pdfium") {
+# complete_static_lib = true }`` precisely so GN embeds every transitive
+# object in the archive instead of emitting a GNU thin archive that
+# references ``.o`` files by sandbox path. The checks below lock that
+# contract in at the end of the build: if any regression ever drops the
+# ``complete_static_lib`` line or the ar backend silently falls back to
+# thin format, the Docker build fails here rather than publishing a
+# ``libpdfium.a`` that downstream consumers can't actually link against.
+_thin_err = "libpdfium.a is a GNU thin archive — complete_static_lib patch regressed"
+_size_err = "libpdfium.a is only $SIZE bytes — expected tens of MB for a complete build"
+_member_err = "only $MEMBERS members — expected thousands for a complete pdfium build"
+VERIFY_COMPLETE_STATIC_LIB = rf"""RUN set -eu; \
+    A=out/Static/obj/libpdfium.a; \
+    MAGIC=$(head -c 7 "$A"); \
+    case "$MAGIC" in \
+        '!<arch>') echo "OK: libpdfium.a has fat-archive magic" ;; \
+        '!<thin>') echo "ERROR: {_thin_err}" >&2; exit 1 ;; \
+        *) echo "ERROR: libpdfium.a has unexpected magic '$MAGIC'" >&2; exit 1 ;; \
+    esac; \
+    ar t "$A" > /tmp/ar-members.txt; \
+    MEMBERS=$(wc -l < /tmp/ar-members.txt); \
+    SIZE=$(stat -c %s "$A"); \
+    echo "libpdfium.a: $MEMBERS members, $SIZE bytes"; \
+    if [ "$MEMBERS" -lt 100 ]; then \
+        echo "ERROR: {_member_err}" >&2; exit 1; \
+    fi; \
+    if [ "$SIZE" -lt 10000000 ]; then \
+        echo "ERROR: {_size_err}" >&2; exit 1; \
+    fi"""
+
+
 def _make_dockerfile_linux(version, arch, plat):
     """Dockerfile for Linux builds (runs in Docker, cross-compiles arm64).
 
@@ -1122,6 +1155,11 @@ RUN ninja -C out/Shared pdfium
 # ninja out-dir root (``out/Shared/libpdfium.so``).
 RUN ls -lh out/Static/obj/libpdfium.a out/Shared/libpdfium.so && \\
     file out/Static/obj/libpdfium.a out/Shared/libpdfium.so
+
+# Step 11b: Strictly verify libpdfium.a is a complete (fat) static archive
+# and not a GNU thin archive. Fails the build if the complete_static_lib
+# patch ever regresses and we emit an unlinkable archive.
+{VERIFY_COMPLETE_STATIC_LIB}
 
 # Step 12: Stage artifacts into /staging
 COPY LICENSE /tmp/LICENSE
@@ -1301,6 +1339,11 @@ RUN ninja -C out/Shared pdfium
 # that's ``obj/libpdfium.a``.
 RUN ls -lh out/Static/obj/libpdfium.a out/Shared/libpdfium.so && \\
     file out/Static/obj/libpdfium.a out/Shared/libpdfium.so
+
+# Step 12b: Strictly verify libpdfium.a is a complete (fat) static archive
+# and not a GNU thin archive. Fails the build if the complete_static_lib
+# patch ever regresses and we emit an unlinkable archive.
+{VERIFY_COMPLETE_STATIC_LIB}
 
 # Step 13: Stage artifacts into /staging
 COPY LICENSE /tmp/LICENSE

--- a/pdfium/tests/test_dockerfile.py
+++ b/pdfium/tests/test_dockerfile.py
@@ -84,6 +84,21 @@ class TestMakeDockerfileLinuxAmd64:
         assert "args.gn /staging/args.gn" in self.df
         assert "args.gn /staging/args.static.gn" in self.df
 
+    def test_verify_rejects_thin_archive(self):
+        assert "'!<thin>'" in self.df
+        assert "complete_static_lib patch regressed" in self.df
+
+    def test_verify_runs_between_shared_build_and_staging(self):
+        static_ninja = self.df.index("ninja -C out/Static pdfium")
+        verify = self.df.index("libpdfium.a has fat-archive magic")
+        stage = self.df.index("cp out/Static/obj/libpdfium.a /staging/lib/")
+        assert static_ninja < verify < stage
+
+    def test_verify_checks_member_count_and_size(self):
+        assert "ar t" in self.df
+        assert "MEMBERS" in self.df
+        assert "SIZE" in self.df
+
 
 class TestMakeDockerfileLinuxArm64:
     def setup_method(self):
@@ -134,6 +149,10 @@ class TestMakeDockerfileMuslAmd64:
     def test_staging_contains_both_artifacts(self):
         assert "libpdfium.so /staging/lib/" in self.df
         assert "libpdfium.a /staging/lib/" in self.df
+
+    def test_verify_complete_static_lib_present(self):
+        assert "libpdfium.a has fat-archive magic" in self.df
+        assert "'!<thin>'" in self.df
 
 
 class TestMakeDockerfileMuslArm64:


### PR DESCRIPTION
## Summary

Add a strict verify step at the end of the Docker build that fails fast if `libpdfium.a` is ever emitted as a GNU thin archive (`!<thin>\n`) instead of a complete fat archive (`!<arch>\n`). Belt-and-braces on top of #7's `complete_static_lib = true` fix.

## Why

Earlier releases (`pdfium-7725` and prior) shipped thin archives — `file libpdfium.a` prints `thin archive` and macOS `ar t` rejects them with `Inappropriate file type or format`. A thin archive only references `.o` files by sandbox path, so once the Docker build container is gone the archive can't be linked. #7 fixed the root cause (rewrite `component()` → `static_library` + `complete_static_lib = true`), but the Dockerfile still only logs `file libpdfium.a` without failing on bad output — a future patch edit, GN change, or ar backend flip could silently re-introduce the regression.

This PR adds, right after the existing `ls -lh`/`file` step:

- archive magic must be `!<arch>\n` (not `!<thin>\n`)
- `ar t` member count must be ≥ 100
- archive size must be ≥ 10 MB

Any of those failing aborts the Docker build with a specific diagnostic on stderr, before the staging step would package a broken archive.

## Shape of the change

- `pdfium/build_pdfium.py` — new module-level `VERIFY_COMPLETE_STATIC_LIB` constant (single shell RUN step) interpolated into both the linux and musl Dockerfiles immediately after the existing post-build verification.
- `pdfium/tests/test_dockerfile.py` — new assertions that lock the verify step's position between the static ninja pass and staging, and assert the thin-archive rejection message, member count, and size checks are emitted.
- `MANUAL.md` — per-combo pipeline description now lists verification as step 5; new troubleshooting entry points at the `!<arch>\n` magic requirement.
- `pdfium/README.md` — build-pipeline section mentions the verify step and the `complete_static_lib` mechanism behind it.

## Test plan

- [x] `pytest pdfium/tests/ -q` → 102 passed
- [x] `ruff check pdfium/` → clean
- [x] `ruff format --check pdfium/` → clean
- [x] pre-commit hook (ruff + shellcheck + pytest) → green
- [ ] Kick the `Build PDFium` workflow on this branch with `version=7725 upload=false` and confirm every combo passes the new verify step (archive magic `!<arch>\n`, members ≥ 100, size ≥ 10 MB)