### PR TITLE
release: pdf_is_complete_lib fat static archive fix

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -44,15 +44,19 @@ Docker, Python, and (for uploads) the `gh` CLI. For each requested
 1. Generates a platform-specific Dockerfile on the fly.
 2. Builds an amd64 Docker image that runs the full compile inside the
    container.
-3. Applies the **base** platform patch (symbol-visibility fixes, the
-   `component("pdfium")` → `static_library("pdfium") {
-   complete_static_lib = true }` rewrite, plus musl-specific toolchain
-   setup where applicable) and runs `ninja` against `out/Static`,
-   producing a complete (fat) `libpdfium.a`.
-4. Applies the **shared** patch on top (rewrites
-   `static_library("pdfium")` → `shared_library("pdfium")` and strips
-   the static-only `complete_static_lib` line) and runs `ninja` against
-   `out/Shared`, producing `libpdfium.so`.
+3. Applies the **base** platform patch (`fpdfview.h` symbol-visibility
+   fix, plus musl-specific toolchain setup where applicable — base mode
+   does **not** rewrite `BUILD.gn`), writes `out/Static/args.gn` with
+   `pdf_is_complete_lib = true`, and runs `ninja` against `out/Static`.
+   The GN flag trips PDFium's own `BUILD.gn` branch that sets
+   `static_component_type = "static_library"`, `complete_static_lib =
+   true`, and strips `//build/config/compiler:thin_archive` from
+   configs, so the pass emits a complete (fat) `libpdfium.a`.
+4. Applies the **shared** patch on top (rewrites `component("pdfium")`
+   → `shared_library("pdfium")` in `BUILD.gn`), writes
+   `out/Shared/args.gn` *without* `pdf_is_complete_lib` (the flag is
+   static-only), and runs `ninja` against `out/Shared`, producing
+   `libpdfium.so`.
 5. **Verifies** `libpdfium.a`: archive magic must be `!<arch>\n` (not
    `!<thin>\n`), archive must have ≥ 100 members and be ≥ 10 MB. Thin
    archives reference `.o` paths inside the build sandbox and would
@@ -411,14 +415,17 @@ pdfium-<platform>-<gn_cpu>/
 
 `args.gn` and `args.static.gn` are kept separate so a consumer
 investigating linker issues can see exactly which flags produced each
-binary. They differ only in the `BUILD.gn` target type that the
-matching patch mode selects: `static_library("pdfium")` under
-`--mode base` (emitting `libpdfium.a` at `out/Static/obj/libpdfium.a`),
-then `shared_library("pdfium")` under `--mode shared` (emitting
-`libpdfium.so` at `out/Shared/libpdfium.so`). The patch must rewrite
-`component()` explicitly because `component()` resolves to `source_set`
-under `is_component_build=false`, which groups objects but does not
-link a `.a`.
+binary. They differ in one line: `args.static.gn` sets
+`pdf_is_complete_lib = true`, which trips PDFium's own BUILD.gn branch
+that selects `static_component_type = "static_library"`,
+`complete_static_lib = true`, and drops the `thin_archive` config — so
+the Static pass emits `libpdfium.a` at `out/Static/obj/libpdfium.a`.
+`args.gn` (the Shared pass) omits that flag because the shared pass
+works off a `BUILD.gn` rewrite applied by `--mode shared`
+(`component("pdfium")` → `shared_library("pdfium")`, required because
+`component()` resolves to `source_set` under `is_component_build=false`
+and would not link a `.so`), emitting `libpdfium.so` at
+`out/Shared/libpdfium.so`.
 
 ## CONSUMING THE ARTIFACTS
 
@@ -519,12 +526,16 @@ GN's `static_library` only archives objects the target *directly*
 owns; PDFium's `pdfium` target is an umbrella with many `deps` and
 almost no direct `sources`, so a naive `component() → static_library`
 rewrite produces an archive containing just the `!<arch>\n` magic
-header. The base-mode patches now insert `complete_static_lib = true`
-into the rewritten target, which tells GN to pull every transitive
-dependency's objects into the archive. If you forked the patches,
-make sure that flag is present on the static target. The shared-mode
-patch strips the flag before rewriting to `shared_library` because
-GN rejects `complete_static_lib` on non-static targets.
+header. The fix is to let PDFium's own `BUILD.gn` handle the static
+wiring: the Static pass writes `pdf_is_complete_lib = true` into
+`out/Static/args.gn`, which trips the branch in `pdfium/BUILD.gn` that
+sets `static_component_type = "static_library"`, `complete_static_lib
+= true`, and strips `//build/config/compiler:thin_archive` from
+configs. If you forked the build script, make sure the Static
+`args.gn` carries that flag — and that the Shared `args.gn` does
+**not**, since the shared pass rewrites the target to
+`shared_library("pdfium")` and GN rejects `complete_static_lib` on
+non-static targets.
 
 ### `ERROR at //build/config/sysroot.gni:60:7: Assertion failed` (musl)
 

--- a/pdfium/README.md
+++ b/pdfium/README.md
@@ -81,11 +81,11 @@ The build pipeline (inspired by [bblanchon/pdfium-binaries](https://github.com/b
 2. Configure gclient with `checkout_configuration=small` (skips V8, test deps, cipd)
 3. Checkout PDFium source at the target chromium branch
 4. Install build dependencies and target architecture sysroot (linux) or musl-cross-make toolchain (musl)
-5. Apply the **base** platform patch — symbol visibility, rewrite `component("pdfium")` to `static_library("pdfium")` with `complete_static_lib = true`, plus musl toolchain GN config where relevant. Chromium's `component()` template resolves to `source_set` (not `static_library`) under `is_component_build=false`, so the explicit `static_library` rewrite is what actually gets a `.a` emitted; `complete_static_lib = true` then forces it to be a fat archive containing every transitive object.
-6. `gn gen out/Static` + `ninja -C out/Static pdfium` — produces `libpdfium.a`
-7. Apply the **shared** platform patch — rewrites `static_library("pdfium")` to `shared_library("pdfium")` and strips the static-only `complete_static_lib` line.
-8. `gn gen out/Shared` + `ninja -C out/Shared pdfium` — produces `libpdfium.so`
-9. **Verify** `libpdfium.a` is a complete fat archive: magic must be `!<arch>\n` (not `!<thin>\n`), archive must have ≥ 100 members and be ≥ 10 MB. A thin archive would reference `.o` files in the now-discarded build sandbox, so the build fails here rather than publish a broken archive.
+5. Apply the **base** platform patch — `fpdfview.h` symbol-visibility fix, plus musl-only toolchain GN config (BUILDCONFIG / highway / musl toolchain install) where relevant. Base mode no longer rewrites `BUILD.gn`.
+6. Write `out/Static/args.gn` with **`pdf_is_complete_lib = true`** and run `gn gen out/Static` + `ninja -C out/Static pdfium` — produces `libpdfium.a`. PDFium's own `BUILD.gn` already has a `pdf_is_complete_lib` branch that sets `static_component_type = "static_library"`, `complete_static_lib = true`, and — critically — strips `//build/config/compiler:thin_archive` from configs. Passing the GN flag triggers that branch, so we no longer patch `BUILD.gn` to obtain a fat archive.
+7. Apply the **shared** platform patch — rewrites `component("pdfium")` → `shared_library("pdfium")` in `BUILD.gn`.
+8. Write `out/Shared/args.gn` *without* `pdf_is_complete_lib` (the flag is static-only — the shared pass compiles `shared_library("pdfium")`) and run `gn gen out/Shared` + `ninja -C out/Shared pdfium` — produces `libpdfium.so`
+9. **Verify** `libpdfium.a` is a complete fat archive: magic must be `!<arch>\n` (not `!<thin>\n`), archive must have ≥ 100 members and be ≥ 10 MB. A thin archive would reference `.o` files in the now-discarded build sandbox, so the build fails here rather than publish a broken archive. This check guards against regressions in the `pdf_is_complete_lib` path (e.g. a future PDFium refactor dropping the config subtraction).
 10. Stage artifacts into a single directory and package as `pdfium-{platform}-{gn_cpu}.tgz`
 
 The two-phase ninja build is the cleanest way to emit both a static archive and a shared library from a single source checkout without duplicating the `component("pdfium")` target body inside `BUILD.gn`. It roughly doubles the ninja time per combo, but the expensive Docker setup steps (apt, depot_tools, gclient sync, runhooks) only run once per combo.
@@ -263,7 +263,7 @@ PDFium is compiled with these GN arguments:
 
 ### Platform patches
 
-Platform-specific patches live in `patches/<platform>.py`. The `--platform` flag selects which patch script to apply during the build. Each patch script accepts a `--mode` flag (`base` / `shared` / `all`) so the build orchestrator can apply only the symbol-visibility patches before the static build and then layer the BUILD.gn shared-library rewrite on top before the second ninja pass.
+Platform-specific patches live in `patches/<platform>.py`. The `--platform` flag selects which patch script to apply during the build. Each patch script accepts a `--mode` flag (`base` / `shared` / `all`) so the build orchestrator can apply only the symbol-visibility (and, on musl, toolchain) patches before the static build, then layer the `BUILD.gn` shared-library rewrite on top before the second ninja pass. The static archive is produced without any `BUILD.gn` rewrite — the Static pass's `args.gn` sets `pdf_is_complete_lib = true`, which triggers PDFium's own fat-archive branch in `BUILD.gn`.
 
 ```
 patches/
@@ -276,13 +276,13 @@ Each `patches/<name>.py` script takes the PDFium source directory as its positio
 
 | Mode | Effect |
 | --- | --- |
-| `base` | Everything needed for the static-archive build: `fpdfview.h` visibility patch, plus musl's BUILDCONFIG / highway / toolchain install where applicable |
+| `base` | Symbol-visibility patch for `fpdfview.h`, plus musl's BUILDCONFIG / highway / toolchain install where applicable. Does **not** touch `BUILD.gn` — the Static pass relies on `pdf_is_complete_lib = true` in `args.gn` to trigger PDFium's own static-library branch. |
 | `shared` | Rewrites `component("pdfium")` → `shared_library("pdfium")` in `BUILD.gn`, applied after the static ninja pass |
 | `all` | Both `base` and `shared` (default — equivalent to running `base` then `shared`) |
 
 The Linux patches apply two changes required to produce a `.so` with exported `FPDF_*` symbols:
 
-1. **BUILD.gn** — changes `component("pdfium")` to `shared_library("pdfium")`. The `component()` macro resolves to `static_library` when `is_component_build=false`, so without this patch the output would be a `.a` archive instead of a `.so`. We exploit this deliberately to get the static archive first, then apply the patch and run ninja a second time to get the shared library.
+1. **BUILD.gn (shared mode only)** — changes `component("pdfium")` to `shared_library("pdfium")`. The `component()` macro resolves to `source_set` when `is_component_build=false`, so without this rewrite the shared pass would not emit a `.so`. Base mode leaves `component("pdfium")` alone; the Static pass takes a different route entirely — `pdf_is_complete_lib = true` in `args.gn` flips PDFium's own BUILD.gn branch that sets `static_component_type = "static_library"` and `complete_static_lib = true`, and strips `//build/config/compiler:thin_archive` from configs so `ar` writes a fat archive (not a GNU thin one).
 
 2. **fpdfview.h** — removes the `#if defined(COMPONENT_BUILD)` guard around `FPDF_EXPORT`. PDFium only applies `__attribute__((visibility("default")))` to its public API when `COMPONENT_BUILD` is defined. Since we set `is_component_build=false` (to get a single `.so` instead of many small ones), `FPDF_EXPORT` resolves to nothing without this patch, and all `FPDF_*` symbols get hidden visibility — making the library unusable via `dlopen`/`dlsym` and unusable when linked statically into a Rust binary that relies on the exported C ABI.
 

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -1073,7 +1073,13 @@ def _make_dockerfile_linux(version, arch, plat):
     gn_cpu = target["gn_cpu"]
     branch = f"chromium/{version}"
     extra_args = GN_ARGS_ARM64 if arch == "arm64" else ""
-    gn_args = gn_args_for(plat, gn_cpu, extra_args)
+    gn_args_shared = gn_args_for(plat, gn_cpu, extra_args)
+    # pdf_is_complete_lib triggers PDFium's own BUILD.gn branch that sets
+    # static_component_type = "static_library", complete_static_lib = true,
+    # and — critically — strips //build/config/compiler:thin_archive from
+    # configs. Without the config subtraction GN's alink runs `ar -T -S …`
+    # and emits a GNU thin archive, which rustc can't bundle into an rlib.
+    gn_args_static = gn_args_for(plat, gn_cpu, f"{extra_args}\npdf_is_complete_lib = true".strip())
 
     # For cross-compilation, install the target arch's cross-compiler
     base_pkgs = "git curl python3 ca-certificates build-essential pkg-config lsb-release sudo file"
@@ -1130,9 +1136,13 @@ RUN python3 build/linux/sysroot_scripts/install-sysroot.py --arch={gn_cpu}
 COPY platform.py /tmp/platform.py
 RUN python3 /tmp/platform.py /build/pdfium --mode base
 
-# Step 6: Configure static build
+# Step 6: Configure static build. pdf_is_complete_lib fires PDFium's own
+# BUILD.gn branch at lines 276-279 which sets static_component_type =
+# "static_library", complete_static_lib = true, and strips the
+# thin_archive config so `ar` emits a fat archive downstream Rust
+# consumers can actually bundle into an rlib.
 RUN mkdir -p out/Static && cat > out/Static/args.gn <<'ARGS'
-{gn_args}ARGS
+{gn_args_static}ARGS
 RUN gn gen out/Static
 
 # Step 7: Build static archive (component() -> static_library -> libpdfium.a)
@@ -1141,9 +1151,11 @@ RUN ninja -C out/Static pdfium
 # Step 8: Apply shared-library patch on top of base
 RUN python3 /tmp/platform.py /build/pdfium --mode shared
 
-# Step 9: Configure shared build
+# Step 9: Configure shared build (pdf_is_complete_lib omitted — the patch
+# already rewrote the target to shared_library and the complete-lib branch
+# is specific to static_library output).
 RUN mkdir -p out/Shared && cat > out/Shared/args.gn <<'ARGS'
-{gn_args}ARGS
+{gn_args_shared}ARGS
 RUN gn gen out/Shared
 
 # Step 10: Build shared library (shared_library -> libpdfium.so)
@@ -1267,7 +1279,15 @@ def _make_dockerfile_musl(version, arch):
     # returned 1 exit status". Pass arm_control_flow_integrity = "none"
     # so the linker doesn't require BTI on the prebuilt toolchain libs.
     extra_args = GN_ARGS_ARM64 if arch == "arm64" else ""
-    gn_args = gn_args_for("musl", gn_cpu, extra_args)
+    gn_args_shared = gn_args_for("musl", gn_cpu, extra_args)
+    # pdf_is_complete_lib triggers PDFium's own BUILD.gn branch that sets
+    # static_component_type = "static_library", complete_static_lib = true,
+    # and — critically — strips //build/config/compiler:thin_archive from
+    # configs. Without the config subtraction GN's alink runs `ar -T -S …`
+    # and emits a GNU thin archive, which rustc can't bundle into an rlib.
+    gn_args_static = gn_args_for(
+        "musl", gn_cpu, f"{extra_args}\npdf_is_complete_lib = true".strip()
+    )
 
     # Map gn_cpu to musl-cross-make target triple prefix
     musl_targets = {
@@ -1321,9 +1341,13 @@ RUN gclient runhooks
 COPY platform.py /tmp/platform.py
 RUN python3 /tmp/platform.py /build/pdfium --mode base
 
-# Step 7: Configure static build
+# Step 7: Configure static build. pdf_is_complete_lib fires PDFium's own
+# BUILD.gn branch at lines 276-279 which sets static_component_type =
+# "static_library", complete_static_lib = true, and strips the
+# thin_archive config so `ar` emits a fat archive downstream Rust
+# consumers can actually bundle into an rlib.
 RUN mkdir -p out/Static && cat > out/Static/args.gn <<'ARGS'
-{gn_args}ARGS
+{gn_args_static}ARGS
 RUN gn gen out/Static
 
 # Step 8: Build static archive (component() -> static_library -> libpdfium.a)
@@ -1332,9 +1356,11 @@ RUN ninja -C out/Static pdfium
 # Step 9: Apply shared-library patch on top of base
 RUN python3 /tmp/platform.py /build/pdfium --mode shared
 
-# Step 10: Configure shared build
+# Step 10: Configure shared build (pdf_is_complete_lib omitted — the patch
+# already rewrote the target to shared_library and the complete-lib branch
+# is specific to static_library output).
 RUN mkdir -p out/Shared && cat > out/Shared/args.gn <<'ARGS'
-{gn_args}ARGS
+{gn_args_shared}ARGS
 RUN gn gen out/Shared
 
 # Step 11: Build shared library (shared_library -> libpdfium.so)

--- a/pdfium/patches/linux.py
+++ b/pdfium/patches/linux.py
@@ -4,26 +4,28 @@
 The patch is split into two modes so a single source checkout can
 produce *both* a static archive and a shared library:
 
-* ``base`` — applied before the static-archive build. Modifies:
+* ``base`` — applied before the static-archive build. Modifies only:
     - ``public/fpdfview.h``: strip the ``COMPONENT_BUILD`` guard around
       ``FPDF_EXPORT`` so the public C API always has
       ``visibility("default")``.
-    - ``BUILD.gn``: rewrite ``component("pdfium")`` to
-      ``static_library("pdfium")``. Chromium's ``component()`` template
-      resolves to ``source_set`` (not ``static_library``) when
-      ``is_component_build=false``, and ``source_set`` does not link
-      a ``.a`` — it only groups objects. Explicit ``static_library``
-      is required to produce ``libpdfium.a``.
+
+  Base mode does NOT touch ``BUILD.gn``. The static archive is produced
+  by passing ``pdf_is_complete_lib = true`` via GN args — PDFium's own
+  ``BUILD.gn`` handles that flag internally (sets
+  ``static_component_type = "static_library"``, ``complete_static_lib
+  = true``, and drops the ``thin_archive`` config). The build script
+  passes this arg directly, so the patch file doesn't need to.
 
 * ``shared`` — applied on top of ``base`` before the second ninja pass.
-  Rewrites ``static_library("pdfium")`` back to ``shared_library("pdfium")``
-  so the same target now links a ``.so``. GN invalidates the target
-  type change and recompiles — acceptable cost for a single-source build.
+  Rewrites the pristine ``component("pdfium")`` to
+  ``shared_library("pdfium")`` so the same target now links a ``.so``.
+  GN invalidates the target type change and recompiles — acceptable
+  cost for a single-source build.
 
 Together this gives us both artifacts from one checkout.
 
-These patches match what bblanchon/pdfium-binaries uses
-(shared_library.patch + public_headers.patch).
+The ``shared`` rewrite matches what bblanchon/pdfium-binaries uses
+(shared_library.patch); the fpdfview edit matches public_headers.patch.
 
 Usage:
     python3 linux.py /path/to/pdfium [--mode base|shared|all]
@@ -35,48 +37,17 @@ import sys
 from pathlib import Path
 
 
-def patch_build_gn_static(pdfium_dir: Path) -> None:
-    """Patch BUILD.gn: component() -> static_library() + complete_static_lib.
-
-    Just renaming ``component("pdfium")`` to ``static_library("pdfium")``
-    produces an 8-byte ar archive (magic header only) because PDFium's
-    ``pdfium`` target has many ``deps`` but almost no direct ``sources``
-    — GN's default ``static_library`` only archives objects the target
-    owns directly, not those pulled in via deps. ``complete_static_lib
-    = true`` tells GN to include every transitive dependency's objects
-    in the archive, producing a self-contained ``libpdfium.a`` that can
-    be linked without re-resolving all of PDFium's third-party deps.
-    """
-    build_gn = pdfium_dir / "BUILD.gn"
-    text = build_gn.read_text()
-    updated = text.replace(
-        'component("pdfium") {',
-        'static_library("pdfium") {\n  complete_static_lib = true',
-    )
-    if updated == text:
-        print('WARNING: component("pdfium") { not found in BUILD.gn — already patched?')
-        return
-    build_gn.write_text(updated)
-    print("Applied: BUILD.gn -> static_library (complete_static_lib)")
-
-
 def patch_build_gn_shared(pdfium_dir: Path) -> None:
-    """Patch BUILD.gn: component()/static_library() -> shared_library().
+    """Patch BUILD.gn: rewrite pristine ``component("pdfium")`` to shared_library.
 
-    Handles both the pristine ``component("pdfium")`` form and the
-    post-``base``-mode ``static_library("pdfium")`` form, so ``shared``
-    works whether or not ``base`` ran first. Also strips the
-    ``complete_static_lib = true`` line that ``base`` inserts —
-    ``complete_static_lib`` is only valid on static_library targets and
-    GN errors out if it appears inside a shared_library.
+    Base mode no longer touches BUILD.gn (the static archive comes from
+    the ``pdf_is_complete_lib = true`` GN arg, which PDFium's own
+    BUILD.gn handles), so by the time ``shared`` runs the file is still
+    in its pristine ``component("pdfium")`` form.
     """
     build_gn = pdfium_dir / "BUILD.gn"
     text = build_gn.read_text()
-    updated = text.replace('static_library("pdfium")', 'shared_library("pdfium")')
-    updated = updated.replace('component("pdfium")', 'shared_library("pdfium")')
-    # Drop the complete_static_lib line that the base patch added; it's
-    # only valid in a static_library target.
-    updated = re.sub(r"\n\s*complete_static_lib = true\s*\n", "\n", updated)
+    updated = text.replace('component("pdfium")', 'shared_library("pdfium")')
     if updated == text:
         print("WARNING: no pdfium target to rewrite in BUILD.gn — already patched?")
         return
@@ -142,9 +113,10 @@ def main() -> None:
         choices=["base", "shared", "all"],
         default="all",
         help=(
-            "base = fpdfview.h + rewrite component() to static_library "
-            "(produces libpdfium.a); shared = rewrite target to shared_library "
-            "(produces libpdfium.so); all = both in sequence (default)."
+            "base = fpdfview.h only (static archive comes from "
+            "pdf_is_complete_lib GN arg, no BUILD.gn rewrite needed); "
+            "shared = rewrite component() to shared_library (produces "
+            "libpdfium.so); all = both in sequence (default)."
         ),
     )
     args = parser.parse_args()
@@ -156,7 +128,6 @@ def main() -> None:
 
     if args.mode in ("base", "all"):
         patch_fpdfview_h(pdfium_dir)
-        patch_build_gn_static(pdfium_dir)
     if args.mode in ("shared", "all"):
         patch_build_gn_shared(pdfium_dir)
 

--- a/pdfium/patches/musl.py
+++ b/pdfium/patches/musl.py
@@ -13,16 +13,17 @@ both ``libpdfium.a`` and ``libpdfium.so``:
     - Install the musl GN toolchain at
       ``build/toolchain/linux/musl/BUILD.gn`` (gcc_toolchain entries for
       x86/x64/arm/arm64 using musl-cross-make prefixes).
-    - ``BUILD.gn``: rewrite ``component("pdfium")`` to
-      ``static_library("pdfium")``. Chromium's ``component()`` template
-      resolves to ``source_set`` (not ``static_library``) under
-      ``is_component_build=false``, and ``source_set`` does not link
-      a ``.a``. Explicit ``static_library`` is required for
-      ``libpdfium.a``.
 
-* ``shared`` — applied on top of ``base``. Rewrites
-  ``static_library("pdfium")`` to ``shared_library("pdfium")`` in
-  BUILD.gn so a second ninja pass yields ``libpdfium.so``.
+  Base mode does NOT touch ``BUILD.gn``. The static archive is produced
+  by passing ``pdf_is_complete_lib = true`` via GN args — PDFium's own
+  ``BUILD.gn`` handles that flag internally (sets
+  ``static_component_type = "static_library"``, ``complete_static_lib
+  = true``, and drops the ``thin_archive`` config). The build script
+  passes this arg directly, so the patch file doesn't need to.
+
+* ``shared`` — applied on top of ``base``. Rewrites the pristine
+  ``component("pdfium")`` to ``shared_library("pdfium")`` in BUILD.gn
+  so a second ninja pass yields ``libpdfium.so``.
 
 All patches match bblanchon/pdfium-binaries (patches/musl/).
 
@@ -36,37 +37,17 @@ import sys
 from pathlib import Path
 
 
-def patch_build_gn_static(pdfium_dir: Path) -> None:
-    """Patch BUILD.gn: component() -> static_library() + complete_static_lib.
-
-    See ``linux.py``'s docstring for why ``complete_static_lib = true``
-    is required: PDFium's ``pdfium`` target is an umbrella with deps but
-    no direct sources, so without this flag the archive is empty.
-    """
-    build_gn = pdfium_dir / "BUILD.gn"
-    text = build_gn.read_text()
-    updated = text.replace(
-        'component("pdfium") {',
-        'static_library("pdfium") {\n  complete_static_lib = true',
-    )
-    if updated == text:
-        print('WARNING: component("pdfium") { not found in BUILD.gn — already patched?')
-        return
-    build_gn.write_text(updated)
-    print("Applied: BUILD.gn -> static_library (complete_static_lib)")
-
-
 def patch_build_gn_shared(pdfium_dir: Path) -> None:
-    """Patch BUILD.gn: component()/static_library() -> shared_library().
+    """Patch BUILD.gn: rewrite pristine ``component("pdfium")`` to shared_library.
 
-    Also strips the ``complete_static_lib = true`` line the base patch
-    adds, since that flag is only valid on static_library targets.
+    Base mode no longer touches BUILD.gn (the static archive comes from
+    the ``pdf_is_complete_lib = true`` GN arg, which PDFium's own
+    BUILD.gn handles), so by the time ``shared`` runs the file is still
+    in its pristine ``component("pdfium")`` form.
     """
     build_gn = pdfium_dir / "BUILD.gn"
     text = build_gn.read_text()
-    updated = text.replace('static_library("pdfium")', 'shared_library("pdfium")')
-    updated = updated.replace('component("pdfium")', 'shared_library("pdfium")')
-    updated = re.sub(r"\n\s*complete_static_lib = true\s*\n", "\n", updated)
+    updated = text.replace('component("pdfium")', 'shared_library("pdfium")')
     if updated == text:
         print("WARNING: no pdfium target to rewrite in BUILD.gn — already patched?")
         return
@@ -276,9 +257,10 @@ def main() -> None:
         choices=["base", "shared", "all"],
         default="all",
         help=(
-            "base = rewrite component() to static_library + musl toolchain/"
-            "config setup (produces libpdfium.a); shared = rewrite target "
-            "to shared_library (produces libpdfium.so); all = both (default)."
+            "base = fpdfview.h + musl toolchain/config setup (static "
+            "archive comes from pdf_is_complete_lib GN arg, no BUILD.gn "
+            "rewrite needed); shared = rewrite component() to "
+            "shared_library (produces libpdfium.so); all = both (default)."
         ),
     )
     args = parser.parse_args()
@@ -293,7 +275,6 @@ def main() -> None:
         patch_buildconfig_gn(pdfium_dir)
         patch_highway_build_gn(pdfium_dir)
         install_musl_toolchain(pdfium_dir)
-        patch_build_gn_static(pdfium_dir)
     if args.mode in ("shared", "all"):
         patch_build_gn_shared(pdfium_dir)
 

--- a/pdfium/tests/test_dockerfile.py
+++ b/pdfium/tests/test_dockerfile.py
@@ -1,10 +1,11 @@
 """Tests for generated Dockerfile content.
 
 The build runs in two phases per platform so the release archive ships
-both ``libpdfium.a`` (from the base patch — ``component()`` stays as
-``static_library``) and ``libpdfium.so`` (from the shared-library
-rewrite applied on top). The assertions below lock in that two-phase
-structure for each platform.
+both ``libpdfium.a`` (from the Static pass, which passes
+``pdf_is_complete_lib = true`` into ``args.gn`` so PDFium's own BUILD.gn
+branch emits a fat ``static_library``) and ``libpdfium.so`` (from the
+shared-library rewrite applied on top). The assertions below lock in
+that two-phase structure for each platform.
 """
 
 import build_pdfium as bp
@@ -84,8 +85,28 @@ class TestMakeDockerfileLinuxAmd64:
         assert "args.gn /staging/args.gn" in self.df
         assert "args.gn /staging/args.static.gn" in self.df
 
+    def test_pdf_is_complete_lib_in_static_args(self):
+        # The static pass writes out/Static/args.gn with pdf_is_complete_lib = true
+        # (triggering PDFium's own complete-lib branch in BUILD.gn); the shared
+        # pass writes out/Shared/args.gn without it. The flag must therefore
+        # appear AFTER the Static args heredoc starts but BEFORE the Shared one.
+        static_args_pos = self.df.index("out/Static/args.gn")
+        shared_args_pos = self.df.index("out/Shared/args.gn")
+        flag_pos = self.df.index("pdf_is_complete_lib = true")
+        assert static_args_pos < flag_pos < shared_args_pos
+
+    def test_pdf_is_complete_lib_not_in_shared_args(self):
+        # pdf_is_complete_lib is specific to the static pass — the shared pass
+        # emits shared_library("pdfium") where the flag doesn't apply. The
+        # string must therefore appear exactly once in the whole Dockerfile
+        # (inside the Static args.gn heredoc).
+        assert self.df.count("pdf_is_complete_lib = true") == 1
+
     def test_verify_rejects_thin_archive(self):
         assert "'!<thin>'" in self.df
+        # Verify step still names the regression so operators see why the
+        # build failed. The exact wording in build_pdfium.py's _thin_err is
+        # "libpdfium.a is a GNU thin archive — complete_static_lib patch regressed".
         assert "complete_static_lib patch regressed" in self.df
 
     def test_verify_runs_between_shared_build_and_staging(self):
@@ -153,6 +174,17 @@ class TestMakeDockerfileMuslAmd64:
     def test_verify_complete_static_lib_present(self):
         assert "libpdfium.a has fat-archive magic" in self.df
         assert "'!<thin>'" in self.df
+
+    def test_pdf_is_complete_lib_in_static_args(self):
+        # Same invariant as the linux dockerfile: pdf_is_complete_lib = true
+        # lives only in the Static args.gn heredoc, not the Shared one.
+        static_args_pos = self.df.index("out/Static/args.gn")
+        shared_args_pos = self.df.index("out/Shared/args.gn")
+        flag_pos = self.df.index("pdf_is_complete_lib = true")
+        assert static_args_pos < flag_pos < shared_args_pos
+
+    def test_pdf_is_complete_lib_not_in_shared_args(self):
+        assert self.df.count("pdf_is_complete_lib = true") == 1
 
 
 class TestMakeDockerfileMuslArm64:


### PR DESCRIPTION
## Summary

Promotes #13 to release to re-publish `pdfium-7725` with fat (complete) `libpdfium.a` on all linux/musl arches.

See #13 for full root-cause analysis.

## Test plan

- [ ] Release workflow completes for all 4 linux/musl jobs
- [ ] Each `pdfium-linux-*.tgz` / `pdfium-musl-*.tgz` unpacks to a `libpdfium.a` starting with `!<arch>\n`
- [ ] Downstream istracked/server rustc build links successfully