### PR TITLE
release: ci fixes (mac bootstrap + musl mirror)

### DIFF
--- a/pdfium/build_mac_native.sh
+++ b/pdfium/build_mac_native.sh
@@ -56,13 +56,19 @@ if [ ! -d "$DEPOT_TOOLS" ]; then
   done
 fi
 export PATH="$DEPOT_TOOLS:$PATH"
-export DEPOT_TOOLS_UPDATE=0
 
 echo "[2/$TOTAL] Bootstrap depot_tools + gsutil"
-# Pre-warming gsutil serializes the bundle download so gclient's parallel
-# workers don't race on flock (same fix as the Linux/musl Dockerfiles).
+# First gclient call triggers depot_tools' first-run bootstrap, which
+# unpacks the hermetic python3 into .cipd_bin and writes the
+# python3_bin_reldir.txt file that `gn gen` reads later. Setting
+# DEPOT_TOOLS_UPDATE=0 here would short-circuit that bootstrap and
+# make `gn gen` fail with "python3_bin_reldir.txt not found. need to
+# initialize depot_tools". Freeze updates AFTER the bootstrap runs.
 gclient --version
 python3 "$DEPOT_TOOLS/gsutil.py" --version
+# Pre-warming gsutil serializes the bundle download so gclient's parallel
+# workers don't race on flock (same fix as the Linux/musl Dockerfiles).
+export DEPOT_TOOLS_UPDATE=0
 
 echo "[3/$TOTAL] gclient config"
 mkdir -p "$BUILD_DIR"

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -1314,6 +1314,8 @@ def _make_dockerfile_musl(version, arch):
         "arm64": "aarch64-linux-musl",
     }
     musl_target = musl_targets[gn_cpu]
+    mirror_base = "https://github.com/libviprs/libviprs-dep/releases/download/musl-cross-mirror"
+    toolchain_tgz = f"{musl_target}-cross.tgz"
 
     return f"""\
 FROM debian:bookworm-slim
@@ -1326,19 +1328,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     && rm -rf /var/lib/apt/lists/*
 
 # Step 1: Install musl-cross-make toolchain.
-# musl.cc is a small single-host mirror that occasionally returns DNS
-# failures or 5xx under load, and also (more subtly) drops the connection
-# mid-stream — the HTTP response starts with 200 OK but the body is
-# truncated. When curl is piped directly into `tar xz`, a short read
-# surfaces as a cryptic tar error and hides the real cause. Download to
-# a file first (with retries), assert the archive is at least 50 MB
-# (real toolchains are ~100 MB — anything smaller is a truncated body
-# or an error page), then extract. --retry-all-errors covers both
-# transient network and HTTP errors so a flake doesn't kill the build.
-RUN curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors \\
-    -o /tmp/tc.tgz "https://musl.cc/{musl_target}-cross.tgz"
+# Primary source is our own GH release mirror
+# (libviprs/libviprs-dep/releases/musl-cross-mirror) — GitHub's CDN is
+# reliably reachable from GH-hosted runners. Upstream musl.cc is a
+# single-host free mirror and has been observed blackholed from GH
+# Actions runners (6 retries × 133 s TCP connect timeouts), so we don't
+# depend on it for CI. Fall back to musl.cc only if the mirror fetch
+# fails for some reason.
+#
+# Download to a file first (with retries) instead of piping into `tar`,
+# then assert size >= 50 MB (real toolchains are ~100 MB — anything
+# smaller is a truncated body or an error page), then extract.
+# --retry-all-errors covers both transient network and HTTP errors.
+# --connect-timeout 30 short-circuits the blackhole case so we fail
+# over to the fallback in seconds rather than minutes.
+RUN curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors \\
+        --connect-timeout 30 -o /tmp/tc.tgz \\
+        "{mirror_base}/{toolchain_tgz}" \\
+    || curl -fsSL --retry 3 --retry-delay 10 --retry-all-errors \\
+        --connect-timeout 30 -o /tmp/tc.tgz \\
+        "https://musl.cc/{toolchain_tgz}"
 RUN test "$(stat -c%s /tmp/tc.tgz)" -gt 50000000 \\
-    || (echo "musl.cc returned a truncated toolchain archive" \\
+    || (echo "toolchain archive truncated" \\
         "($(stat -c%s /tmp/tc.tgz) bytes < 50MB); aborting." >&2; exit 1)
 RUN tar xzf /tmp/tc.tgz -C /opt && rm /tmp/tc.tgz
 ENV PATH="/opt/{musl_target}-cross/bin:${{PATH}}"

--- a/pdfium/tests/test_dockerfile.py
+++ b/pdfium/tests/test_dockerfile.py
@@ -173,11 +173,19 @@ class TestMakeDockerfileMuslAmd64:
         assert "tar xzf /tmp/tc.tgz -C /opt" in self.df
 
     def test_musl_toolchain_download_retries(self):
-        # The toolchain URL is a single-host mirror prone to flakes —
-        # keep the retry/backoff flags on the curl command.
-        assert "--retry 5" in self.df
-        assert "--retry-delay 10" in self.df
-        assert "--retry-all-errors" in self.df
+        # Keep retry/backoff flags on both the primary (GH mirror) and
+        # fallback (musl.cc) curls so a single transient failure doesn't
+        # kill the build.
+        assert self.df.count("--retry-all-errors") >= 2
+        assert self.df.count("--connect-timeout 30") >= 2
+
+    def test_musl_toolchain_mirror_primary(self):
+        # Our libviprs-dep releases mirror is the primary source; musl.cc
+        # is only a fallback (GH Actions runners intermittently blackhole
+        # TCP to musl.cc).
+        mirror_pos = self.df.index("libviprs/libviprs-dep/releases/download/musl-cross-mirror/")
+        muslcc_pos = self.df.index("https://musl.cc/")
+        assert mirror_pos < muslcc_pos
 
     def test_target_cpu_x64(self):
         assert 'target_cpu = "x64"' in self.df


### PR DESCRIPTION
Promotes #17 to release to re-run the matrix with mac depot_tools first-run bootstrap restored and musl toolchain pulled from the libviprs-dep GH release mirror (decoupled from musl.cc blackhole).