### PR TITLE
release: pdfium mac/x64, mac-universal, Xcode 26.0 pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,16 @@ jobs:
     # Mac must run on a macOS runner — PDFium's `gn gen` invokes
     # `xcodebuild`, which doesn't exist inside the Debian container used
     # for linux/musl. bblanchon/pdfium-binaries uses the same macos-15
-    # approach.
+    # approach. We fan out arm64 and amd64 into separate jobs so a flake
+    # on one doesn't block the other and so build-mac-universal can lipo
+    # the two resulting dylibs into a single fat Mach-O.
     needs: [resolve-version, create-release]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: arm64 }
+          - { arch: amd64 }
     runs-on: macos-15
     timeout-minutes: 120
     permissions:
@@ -143,27 +151,88 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Build + publish mac/arm64
+      - name: Build + publish mac/${{ matrix.arch }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 pdfium/build_pdfium.py "${{ needs.resolve-version.outputs.version }}" \
-            --platform mac --arch arm64 --upload
+            --platform mac --arch ${{ matrix.arch }} --upload
 
       - name: Upload build logs on failure
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: logs-mac-arm64
+          name: logs-mac-${{ matrix.arch }}
           path: bin/logs/
           if-no-files-found: warn
+
+  build-mac-universal:
+    # Fuse the per-arch mac dylibs into a single universal Mach-O using
+    # `lipo -create`, matching bblanchon/pdfium-binaries' mac-univ.yml
+    # pattern. Downloads the per-arch tarballs from the release we just
+    # published, swaps in the combined dylib, and uploads the result as
+    # pdfium-mac-univ.tgz alongside the per-arch archives.
+    needs: [resolve-version, create-release, build-mac]
+    runs-on: macos-15
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download mac/arm64 and mac/x64 release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-version.outputs.tag }}
+        run: |
+          set -eu
+          mkdir -p work
+          cd work
+          gh release download "$TAG" \
+            --pattern 'pdfium-mac-arm64.tgz' \
+            --pattern 'pdfium-mac-x64.tgz'
+          tar xzf pdfium-mac-arm64.tgz
+          tar xzf pdfium-mac-x64.tgz
+
+      - name: Lipo-combine into universal dylib
+        run: |
+          set -eux
+          cd work
+          cp -R pdfium-mac-arm64 pdfium-mac-univ
+          # The arch-specific target_cpu in args.gn would lie for a
+          # universal binary; strip it so the args.gn documents only the
+          # shared flags. The per-arch tarballs still carry the truthful
+          # target_cpu for anyone who needs it.
+          sed -i '' '/^target_cpu/d' pdfium-mac-univ/args.gn
+          rm pdfium-mac-univ/lib/libpdfium.dylib
+          lipo -create \
+            pdfium-mac-arm64/lib/libpdfium.dylib \
+            pdfium-mac-x64/lib/libpdfium.dylib \
+            -output pdfium-mac-univ/lib/libpdfium.dylib
+          file pdfium-mac-univ/lib/libpdfium.dylib
+          tar czf pdfium-mac-univ.tgz pdfium-mac-univ
+          ls -lh pdfium-mac-univ.tgz
+
+      - name: Upload pdfium-mac-univ.tgz to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-version.outputs.tag }}
+        run: |
+          gh release upload "$TAG" work/pdfium-mac-univ.tgz --clobber
 
   summary:
     # Prints the final release URL + per-job status once every build has
     # either succeeded or failed. Doesn't gate on success — needs:
     # [...] with if: always() lets this run even if some jobs failed,
     # so the release URL is surfaced regardless of partial completion.
-    needs: [resolve-version, create-release, build-linux, build-mac]
+    needs:
+      [
+        resolve-version,
+        create-release,
+        build-linux,
+        build-mac,
+        build-mac-universal,
+      ]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -181,6 +250,7 @@ jobs:
             echo ""
             echo "| Job | Result |"
             echo "| --- | --- |"
-            echo "| build-linux   | ${{ needs.build-linux.result }} |"
-            echo "| build-mac     | ${{ needs.build-mac.result }} |"
+            echo "| build-linux         | ${{ needs.build-linux.result }} |"
+            echo "| build-mac           | ${{ needs.build-mac.result }} |"
+            echo "| build-mac-universal | ${{ needs.build-mac-universal.result }} |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -105,6 +105,15 @@ has shipped Apple Silicon exclusively for new Macs since 2020, so the
 x86_64 dylib is rarely useful. Request it explicitly with
 `--platform mac --arch amd64` when building on a macOS host.
 
+The release workflow (`.github/workflows/release.yml`) ships both
+per-arch mac archives — `pdfium-mac-arm64.tgz` and `pdfium-mac-x64.tgz`
+— and, after both succeed, a `build-mac-universal` job runs `lipo
+-create` over the two dylibs and uploads a third archive,
+`pdfium-mac-univ.tgz`, containing a single fat Mach-O that loads on
+either architecture. This fat-archive step has no `build_pdfium.py`
+equivalent — it only exists as a CI post-processing job, mirroring
+bblanchon/pdfium-binaries' `mac-univ.yml`.
+
 Every compile runs inside an amd64 Linux container regardless of the
 host's CPU arch. `build_pdfium.py` forces `--platform=linux/amd64` on
 every `docker build` / `docker create` so Apple Silicon and Linux-arm64
@@ -383,9 +392,16 @@ by a merge to `release`. It reads the chromium branch from
 
 - Four `ubuntu-latest` jobs — `{linux, musl} × {amd64, arm64}` — each
   calls `build_pdfium.py --platform X --arch Y --upload`.
-- One `macos-15` job runs the same command with `--platform mac
-  --arch arm64`; `build_pdfium.py` detects the Darwin host and dispatches
-  to `pdfium/build_mac_native.sh` instead of its Docker path.
+- Two `macos-15` matrix jobs — `mac/arm64` and `mac/amd64` — each
+  calls `build_pdfium.py --platform mac --arch Y --upload`;
+  `build_pdfium.py` detects the Darwin host and dispatches to
+  `pdfium/build_mac_native.sh` instead of its Docker path.
+- One further `macos-15` job (`build-mac-universal`) runs after both
+  per-arch mac builds succeed. It downloads `pdfium-mac-arm64.tgz` and
+  `pdfium-mac-x64.tgz` from the just-published release, `lipo
+  -create`s the two `libpdfium.dylib` files into a universal Mach-O,
+  and uploads the result as `pdfium-mac-univ.tgz`. Matches the pattern
+  in bblanchon/pdfium-binaries' `mac-univ.yml`.
 
 A preceding `create-release` job ensures the `pdfium-<VERSION>` tag
 exists before any build job uploads, so parallel `gh release upload

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pdfium-<platform>-<cpu>/
 └── LICENSE
 ```
 
-The default release matrix is `{linux, musl} × {amd64, arm64}` — four archives per tag. Pick the `linux-*` archives for glibc runtimes (Debian, Ubuntu, …) and the `musl-*` archives for musl runtimes (Alpine, musl-based distroless images). Loading a glibc `.so` from a musl process — or vice versa — fails at `dlopen` time. macOS is intentionally excluded from the default matrix: PDFium's GN config invokes `xcodebuild` during `gn gen`, which doesn't exist on Linux, so mac builds require an actual macOS host (bblanchon/pdfium-binaries runs mac builds on `macos-15` GitHub Actions runners for the same reason).
+The default in-process matrix (`build_pdfium.py` on a Linux host) is `{linux, musl} × {amd64, arm64}` — four archives. The release workflow additionally produces three macOS archives on `macos-15` runners: `pdfium-mac-arm64.tgz`, `pdfium-mac-x64.tgz`, and `pdfium-mac-univ.tgz` (a universal Mach-O built via `lipo -create` over the two per-arch dylibs). Pick the `linux-*` archives for glibc runtimes (Debian, Ubuntu, …), the `musl-*` archives for musl runtimes (Alpine, musl-based distroless images), and one of the `mac-*` archives for macOS (`mac-univ` if you want a single binary that loads on both Apple Silicon and Intel). Loading a glibc `.so` from a musl process — or vice versa — fails at `dlopen` time. macOS is intentionally excluded from `build_pdfium.py`'s in-process default matrix because PDFium's GN config invokes `xcodebuild` during `gn gen`, which doesn't exist on Linux, so mac builds require an actual macOS host (bblanchon/pdfium-binaries runs mac builds on `macos-15` GitHub Actions runners for the same reason).
 
 See [`pdfium/README.md`](pdfium/README.md#download) for direct download URLs and consumption examples.
 
@@ -60,7 +60,8 @@ Or trigger the **Build PDFium** GitHub Actions workflow via `workflow_dispatch`,
 2. Merge the PR into the `release` branch.
 3. The **Release** workflow (`.github/workflows/release.yml`) fires on push to `release` and fans out:
    - Four `ubuntu-latest` jobs build `{linux, musl} × {amd64, arm64}` via Docker.
-   - One `macos-15` job builds `mac/arm64` natively (via `pdfium/build_mac_native.sh`, since `xcodebuild` isn't available inside the Debian container used for the others).
+   - Two `macos-15` matrix jobs build `mac/arm64` and `mac/amd64` natively (via `pdfium/build_mac_native.sh`, since `xcodebuild` isn't available inside the Debian container used for the others).
+   - A follow-up `macos-15` job (`build-mac-universal`) downloads the two per-arch mac archives and `lipo -create`s their `libpdfium.dylib` files into a universal Mach-O, uploading it as `pdfium-mac-univ.tgz`.
 4. Each job runs `build_pdfium.py --upload`, which uploads its archive to the `pdfium-<VERSION>` GitHub Release with `gh release upload --clobber`. Parallel uploads are safe because a preceding `create-release` job ensures the tag exists before the fan-out, and `--clobber` replaces only matching asset names.
 5. A final `summary` job posts the release URL + each job's result to the workflow run's summary page.
 

--- a/pdfium/README.md
+++ b/pdfium/README.md
@@ -13,12 +13,14 @@ We compile PDFium from source rather than using third-party prebuilt binaries to
 
 ## Download
 
-Archives are available from [Releases](https://github.com/libviprs/libviprs-dep/releases). Each release tag bundles five archives covering the default matrix (`{linux, musl}` × `{x64, arm64}` plus `mac/arm64`):
+Archives are available from [Releases](https://github.com/libviprs/libviprs-dep/releases). Each release tag bundles the four Linux archives covering the default matrix (`{linux, musl}` × `{x64, arm64}`) plus three macOS archives (`mac-arm64`, `mac-x64`, and `mac-univ`, the latter being a `lipo`-combined fat Mach-O):
 
 ```
 https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-x64.tgz
 https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-arm64.tgz
 https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-mac-arm64.tgz
+https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-mac-x64.tgz
+https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-mac-univ.tgz
 https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-musl-x64.tgz
 https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-musl-arm64.tgz
 ```
@@ -28,8 +30,10 @@ https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-mu
 | `linux-x64`, `linux-arm64` | glibc | Debian, Ubuntu, RHEL, most mainstream distros |
 | `musl-x64`, `musl-arm64`   | musl  | Alpine, any container built `FROM alpine:*`, musl-based distroless images |
 | `mac-arm64`                | —     | macOS 11+ on Apple Silicon (`libpdfium.dylib`) |
+| `mac-x64`                  | —     | macOS 11+ on Intel (`libpdfium.dylib`) |
+| `mac-univ`                 | —     | macOS 11+ on both Apple Silicon and Intel — universal Mach-O combining the arm64 + x64 dylibs via `lipo -create` |
 
-Intel Mac (`mac-x64`) is not in the default matrix — Apple has shipped Apple Silicon exclusively for new Macs since 2020, so the x86_64 dylib is rarely useful. Build one explicitly with `--platform mac --arch x86_64` if you need it.
+Intel Mac (`mac-x64`) and the universal Mach-O (`mac-univ`) are built on the CI matrix but aren't part of the in-process `build_pdfium.py` default matrix (`--platform mac` alone still builds arm64). On the release workflow, `build-mac-universal` runs after both per-arch mac builds succeed, downloads the two dylibs, and `lipo -create`s them into `pdfium-mac-univ.tgz`.
 
 Pick the archive whose libc matches the runtime that will load PDFium. Loading a glibc `.so` from a musl process (or vice versa) fails at `dlopen` time with opaque errors — the libc mismatch is the single most common source of "pdfium doesn't load in my container" tickets.
 
@@ -152,16 +156,16 @@ Archives are written to `./bin/` by default (gitignored). With the default platf
 bin/
   pdfium-linux-x64.tgz
   pdfium-linux-arm64.tgz
-  pdfium-mac-arm64.tgz
   pdfium-musl-x64.tgz
   pdfium-musl-arm64.tgz
   logs/
     linux-amd64.log
     linux-arm64.log
-    mac-arm64.log
     musl-amd64.log
     musl-arm64.log
 ```
+
+On a macOS host, additionally invoking `--platform mac --arch amd64` / `--arch arm64` produces `pdfium-mac-x64.tgz` and `pdfium-mac-arm64.tgz`. The release workflow combines those two per-arch archives into a `pdfium-mac-univ.tgz` (universal Mach-O built via `lipo -create`) in a dedicated CI job — there is no local equivalent inside `build_pdfium.py`, so the universal archive only exists on the release tag.
 
 Each job streams its full Docker build output to `bin/logs/<plat>-<arch>.log` in addition to the terminal view. When a parallel build fails the log file is the authoritative post-mortem record — the in-terminal view switcher only retains the last ~500 output lines per job, but the log on disk has every line plus a header (version, start timestamp) and a failure footer with the exception type. On failure the script prints the log path to stderr so you can `tail -n 200 bin/logs/<plat>-<arch>.log` directly.
 

--- a/pdfium/build_mac_native.sh
+++ b/pdfium/build_mac_native.sh
@@ -46,6 +46,23 @@ TOTAL=10
 mkdir -p "$WORKSPACE" "$OUTPUT_DIR"
 rm -rf "$BUILD_DIR" "$STAGING" "$ARCHIVE"
 
+# Pin Xcode to 26.0 — the macos-15 runner's default is Xcode 16.4, which
+# ships MacOSX15.5.sdk. Chromium's 7725 branch generates ninja rules that
+# reference DarwinFoundation1.modulemap from the SDK, but Apple removed
+# that file in the 15.5 SDK layout — ninja then fails with
+# "missing and no known rule to make it". Xcode 26.0's MacOSX26.0.sdk
+# still has the file. bblanchon/pdfium-binaries pins the same version
+# in steps/01-install.sh for the same reason. Export DEVELOPER_DIR
+# instead of running `sudo xcode-select -s` so the script is safe to
+# run locally without modifying the developer's global toolchain.
+XCODE_PIN="/Applications/Xcode_26.0.app"
+if [ -d "$XCODE_PIN" ]; then
+  export DEVELOPER_DIR="$XCODE_PIN/Contents/Developer"
+  echo "Using $DEVELOPER_DIR"
+else
+  echo "WARNING: $XCODE_PIN not installed — using current xcode-select ($(xcode-select -p))"
+fi
+
 echo "[1/$TOTAL] Install depot_tools"
 if [ ! -d "$DEPOT_TOOLS" ]; then
   i=0


### PR DESCRIPTION
## Summary

Promotes the mac build pipeline changes to the release branch to trigger a new pdfium-7725 build cycle.

- PR #19 (squash 8a1cffa) adds mac/x64 and mac-universal dylib jobs to the release matrix and pins Xcode 26.0 in `build_mac_native.sh` so ninja can find `DarwinFoundation1.modulemap` (missing from MacOSX15.5.sdk on the default macos-15 runner).

Expected release artifacts on `pdfium-7725` after this promotes:
- `pdfium-linux-x64.tgz` / `pdfium-linux-arm64.tgz`
- `pdfium-musl-x64.tgz` / `pdfium-musl-arm64.tgz`
- `pdfium-mac-x64.tgz` / `pdfium-mac-arm64.tgz`
- `pdfium-mac-univ.tgz`

## Test plan
- [ ] release workflow runs to completion (all 7 jobs green)
- [ ] each `.tgz` contains a fat `libpdfium.a` (`!<arch>` magic) and a valid shared library
- [ ] `lipo -info pdfium-mac-univ/lib/libpdfium.dylib` reports both `arm64` and `x86_64`