### PR TITLE
release: pdfium-7725 — libpdfium.a rustc-linkable + verify gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,11 @@ jobs:
           - { platform: mac,   arch: arm64 }
           - { platform: musl,  arch: amd64 }
           - { platform: musl,  arch: arm64 }
-    runs-on: ubuntu-latest
+    # Mac needs a macOS host — gn gen invokes xcodebuild during setup.
+    # All other combos build under a Chromium sysroot and cross-compile
+    # fine from linux. release.yml uses the same split (build-mac on
+    # macos-15, build-linux on ubuntu-latest).
+    runs-on: ${{ matrix.platform == 'mac' && 'macos-15' || 'ubuntu-latest' }}
     # Two ninja phases per archive (static + shared) plus cross-compile for
     # arm64 pushes each combo well past the single-phase budget. 90 minutes
     # gives headroom without letting a hung build loiter forever.
@@ -40,9 +44,14 @@ jobs:
           --platform ${{ matrix.platform }}
           --arch ${{ matrix.arch }}
       - name: Verify archive contents
+        # build_pdfium.py's --output-dir defaults to ./bin (relative to cwd,
+        # which is the repo root when invoked as `python3 pdfium/build_pdfium.py …`).
+        # Earlier versions of this workflow wrote `cd pdfium/bin`, which never
+        # existed; the step has been silently path-errored ever since the default
+        # was set. Keep it as `cd bin` so the tarball structure is actually checked.
         run: |
           set -eu
-          cd pdfium/bin
+          cd bin
           ls -lh
           for f in pdfium-${{ matrix.platform }}-*.tgz; do
             echo "=== $f ==="
@@ -57,10 +66,20 @@ jobs:
                 || { echo "missing libpdfium.a in $f";  exit 1; }
             fi
           done
+
+      - name: Verify archive symbols
+        # Same invariants release.yml enforces — leaked Chromium std::__Cr::
+        # symbols, stripped FPDF_* C API, or missing standard C++ runtime
+        # all fail the build here before the artifact is uploaded.
+        run: |
+          for f in bin/pdfium-${{ matrix.platform }}-*.tgz; do
+            bash pdfium/scripts/verify_archive.sh "$f"
+          done
+
       - uses: actions/upload-artifact@v4
         with:
           name: pdfium-${{ matrix.platform }}-${{ matrix.arch }}
-          path: pdfium/bin/pdfium-*.tgz
+          path: bin/pdfium-*.tgz
 
   release:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,17 +102,37 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Build + publish ${{ matrix.platform }}/${{ matrix.arch }}
-        env:
-          # GITHUB_TOKEN is minted automatically for every run; the gh
-          # CLI picks it up from GH_TOKEN. permissions.contents: write
-          # above is what grants write access to Releases on this repo.
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build ${{ matrix.platform }}/${{ matrix.arch }}
+        # No --upload yet: build first, then verify, then upload. That
+        # ordering ensures a bad archive (leaked __Cr symbols, stripped
+        # FPDF_* API, missing libstdc++) can never reach the Release page.
         run: |
           python3 pdfium/build_pdfium.py "${{ needs.resolve-version.outputs.version }}" \
             --platform ${{ matrix.platform }} \
-            --arch ${{ matrix.arch }} \
-            --upload
+            --arch ${{ matrix.arch }}
+
+      - name: Verify archive symbols
+        # Blocks the upload if any rustc-linkability invariant breaks.
+        # See pdfium/scripts/verify_archive.sh for the full invariant set.
+        run: |
+          shopt -s nullglob
+          for tgz in bin/pdfium-${{ matrix.platform }}-*.tgz; do
+            bash pdfium/scripts/verify_archive.sh "$tgz"
+          done
+
+      - name: Upload release assets ${{ matrix.platform }}/${{ matrix.arch }}
+        # GITHUB_TOKEN is minted automatically for every run; the gh CLI
+        # picks it up from GH_TOKEN. permissions.contents: write above is
+        # what grants write access to Releases on this repo. --clobber so
+        # re-runs replace their own assets without touching others.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-version.outputs.tag }}
+        run: |
+          shopt -s nullglob
+          assets=(bin/pdfium-${{ matrix.platform }}-*.tgz)
+          [ ${#assets[@]} -gt 0 ] || { echo "no archives to upload" >&2; exit 1; }
+          gh release upload "$TAG" "${assets[@]}" --clobber
 
       - name: Upload build logs on failure
         if: always()
@@ -151,12 +171,28 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Build + publish mac/${{ matrix.arch }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build mac/${{ matrix.arch }}
+        # Split from upload so the Verify step below can gate publication.
         run: |
           python3 pdfium/build_pdfium.py "${{ needs.resolve-version.outputs.version }}" \
-            --platform mac --arch ${{ matrix.arch }} --upload
+            --platform mac --arch ${{ matrix.arch }}
+
+      - name: Verify archive symbols
+        run: |
+          shopt -s nullglob
+          for tgz in bin/pdfium-mac-*.tgz; do
+            bash pdfium/scripts/verify_archive.sh "$tgz"
+          done
+
+      - name: Upload release assets mac/${{ matrix.arch }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve-version.outputs.tag }}
+        run: |
+          shopt -s nullglob
+          assets=(bin/pdfium-mac-*.tgz)
+          [ ${#assets[@]} -gt 0 ] || { echo "no archives to upload" >&2; exit 1; }
+          gh release upload "$TAG" "${assets[@]}" --clobber
 
       - name: Upload build logs on failure
         if: always()
@@ -212,6 +248,13 @@ jobs:
           file pdfium-mac-univ/lib/libpdfium.dylib
           tar czf pdfium-mac-univ.tgz pdfium-mac-univ
           ls -lh pdfium-mac-univ.tgz
+
+      - name: Verify universal archive symbols
+        # The per-arch dylibs were already verified by build-mac. Re-verify
+        # the lipo'd output: a future regression in our lipo flags (e.g.
+        # accidentally dropping one slice, or stripping debug sections)
+        # would still be caught here before it reaches the Release page.
+        run: bash pdfium/scripts/verify_archive.sh work/pdfium-mac-univ.tgz
 
       - name: Upload pdfium-mac-univ.tgz to release
         env:

--- a/pdfium/build_mac_native.sh
+++ b/pdfium/build_mac_native.sh
@@ -108,6 +108,21 @@ echo "[6/$TOTAL] Apply mac patches"
 python3 "$REPO_ROOT/pdfium/patches/mac.py" "$PDFIUM" --mode all
 
 echo "[7/$TOTAL] gn gen"
+# Keep Chromium's bundled libc++ (use_custom_libcxx = true, the default)
+# for the mac dylib — dlopen consumers never see internal __Cr:: symbols
+# so the Chromium-namespaced libc++ inside the shared object is harmless.
+# This mirrors the linux .so path: libcxx overrides apply to the static
+# archive only, because rustc (the only consumer that actually links
+# against internal C++ symbols) can't resolve __Cr::.
+#
+# Setting use_custom_libcxx = false here additionally breaks on Xcode
+# 26.0 / MacOSX26.0.sdk: Chromium's gen/third_party/libc++ module sources
+# still get compiled but miss macros like
+# _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD that are only defined when the
+# bundled libc++ is active, failing with "unknown type name" on every
+# std:: template. A mac static build would need its own out/Static dir
+# with the override isolated to that dir (see build_pdfium.py for the
+# linux version), but this script currently only produces a .dylib.
 mkdir -p out/Release
 cat > out/Release/args.gn <<EOF
 is_debug = false

--- a/pdfium/build_pdfium.py
+++ b/pdfium/build_pdfium.py
@@ -137,9 +137,17 @@ def resolve_jobs(platform_flag, arch_flag):
 # pdf_enable_v8             — no JS engine (not needed for rasterization)
 # pdf_enable_xfa            — no XFA form support
 # is_component_build        — single .so, not many small ones
-# use_custom_libcxx         — bundle libc++ so .so is portable across distros
 # pdf_use_partition_alloc   — skip complex allocator (fails on some platforms)
 # clang_use_chrome_plugins  — skip Chrome's custom clang plugins
+#
+# use_custom_libcxx — set false for the STATIC build only (see
+# LIBCXX_STANDARD_ARGS below). When true, Chromium's build compiles against
+# its bundled libc++ with -D_LIBCPP_ABI_NAMESPACE=__Cr, producing
+# std::__Cr::* symbols in the archive. rustc consumers (via
+# pdfium-render/static with the libstdc++ feature) link against the system
+# C++ runtime and cannot resolve __Cr symbols. The SHARED build keeps
+# Chromium's defaults — dlopen consumers of libpdfium.so never resolve
+# internal C++ symbols, only the public FPDF_* C API.
 GN_ARGS_COMMON = """\
 is_debug = false
 pdf_is_standalone = true
@@ -155,6 +163,11 @@ target_cpu = "{gn_cpu}"
 """
 
 # Per-platform GN args appended to GN_ARGS_COMMON.
+#
+# Only the SHARED build uses these directly. The STATIC build adds
+# LIBCXX_STANDARD_ARGS_STATIC on top (see below) — and keeping the shared
+# build on Chromium's default libc++/sysroot combo matters for linux/arm64
+# cross-compile, which relies on the bundled sysroot for glib/nss/fontconfig.
 GN_ARGS_PLATFORM = {
     "linux": 'target_os = "linux"\nuse_custom_libcxx = true',
     "mac": 'target_os = "mac"',
@@ -175,11 +188,51 @@ GN_ARGS_PLATFORM = {
 }
 
 
+# GN args appended ONLY to the static build on linux + mac so libpdfium.a
+# exports the system C++ runtime's std::* symbols instead of Chromium's
+# std::__Cr::* custom namespace. Rust consumers (pdfium-render/static
+# with the libstdc++ feature) link against the system C++ runtime and
+# cannot resolve __Cr symbols — a libpdfium.a built with Chromium's
+# bundled libc++ is unusable. The shared build doesn't need these flags:
+# libpdfium.so is loaded at runtime via dlopen, and consumers only resolve
+# the public FPDF_* C API — never internal C++ symbols.
+#
+# On linux, use_sysroot=false is also required because Chromium's pinned
+# debian_bookworm sysroot ships libc headers but NOT libstdc++ headers.
+# build-essential (already in the Dockerfile) supplies libstdc++-12-dev
+# at the host include paths instead. Not needed on mac (Xcode SDK ships
+# libc++ headers in its default location). NOT applied to the shared
+# build because arm64 cross-compile of the shared library relies on the
+# sysroot for bundled glib/nss/fontconfig — SOLINK would fail without it.
+#
+# musl isn't in this dict — its SHARED build already disables custom
+# libc++ in GN_ARGS_PLATFORM (musl-cross-make ships libstdc++ in its own
+# sysroot), so both static and shared output standard symbols for free.
+LIBCXX_STANDARD_ARGS_STATIC = {
+    "linux": ("use_custom_libcxx = false\nuse_custom_libcxx_for_host = false\nuse_sysroot = false"),
+    "mac": ("use_custom_libcxx = false\nuse_custom_libcxx_for_host = false"),
+}
+
+
 def gn_args_for(plat, gn_cpu, extra_args):
     """Build the full GN args string for a platform + architecture."""
     platform_args = GN_ARGS_PLATFORM.get(plat, "")
     all_extra = "\n".join(filter(None, [platform_args, extra_args]))
     return GN_ARGS_COMMON.format(gn_cpu=gn_cpu, extra_args=all_extra)
+
+
+def gn_args_static_for(plat, gn_cpu, extra_args):
+    """GN args for the libpdfium.a build path.
+
+    Same as gn_args_for but also appends LIBCXX_STANDARD_ARGS_STATIC on
+    platforms that need it, so the archive exports std::__cxx11::* /
+    std::__1::* symbols that rustc consumers can resolve.
+    """
+    static_extra_args = extra_args
+    standard_args = LIBCXX_STANDARD_ARGS_STATIC.get(plat)
+    if standard_args:
+        static_extra_args = "\n".join(filter(None, [extra_args, standard_args]))
+    return gn_args_for(plat, gn_cpu, static_extra_args)
 
 
 # arm64: disable Branch Target Identification enforcement — the Debian
@@ -1098,7 +1151,13 @@ def _make_dockerfile_linux(version, arch, plat):
     # and — critically — strips //build/config/compiler:thin_archive from
     # configs. Without the config subtraction GN's alink runs `ar -T -S …`
     # and emits a GNU thin archive, which rustc can't bundle into an rlib.
-    gn_args_static = gn_args_for(plat, gn_cpu, f"{extra_args}\npdf_is_complete_lib = true".strip())
+    # Static build additionally gets LIBCXX_STANDARD_ARGS_STATIC appended
+    # (via gn_args_static_for) so libpdfium.a exports std::__cxx11::*
+    # libstdc++ symbols rustc consumers can resolve — not Chromium's
+    # std::__Cr:: custom namespace.
+    gn_args_static = gn_args_static_for(
+        plat, gn_cpu, f"{extra_args}\npdf_is_complete_lib = true".strip()
+    )
 
     # For cross-compilation, install the target arch's cross-compiler
     base_pkgs = "git curl python3 ca-certificates build-essential pkg-config lsb-release sudo file"

--- a/pdfium/scripts/verify_archive.sh
+++ b/pdfium/scripts/verify_archive.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Verify a freshly-built PDFium release archive is linkable from rustc
+# against the system C++ runtime (libstdc++ on linux, Apple libc++ on
+# mac). Runs as the last step of every release build job and blocks the
+# upload if any invariant is broken.
+#
+# Usage: verify_archive.sh <tgz-or-lib-path> [platform]
+#
+#   tgz-or-lib-path   path to pdfium-<platform>-<arch>.tgz, or directly
+#                     to libpdfium.{a,so,dylib} (skips extraction).
+#   platform          linux | musl | mac (auto-detected from filename
+#                     if omitted).
+#
+# Invariants enforced:
+#   1. Required FPDF_* C API symbols are defined (public ABI intact).
+#   2. No std::__Cr::* symbols anywhere (Chromium's custom libc++
+#      namespace that breaks rustc linking).
+#   3. On linux/musl: std::__cxx11:: libstdc++ symbols present.
+#      On mac:        std::__1:: Apple libc++ symbols present.
+#   4. No UNDEFINED __Cr references either (catches partial link).
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <tgz-or-lib-path> [platform]" >&2
+  echo "  platform: linux | musl | mac (auto-detected if omitted)" >&2
+}
+
+if [ $# -lt 1 ]; then
+  echo "Error: missing archive path" >&2
+  usage
+  exit 2
+fi
+
+INPUT="$1"
+PLATFORM="${2:-}"
+
+if [ ! -e "$INPUT" ]; then
+  echo "Error: $INPUT does not exist" >&2
+  exit 2
+fi
+
+# Auto-detect platform from filename if not provided.
+if [ -z "$PLATFORM" ]; then
+  case "$(basename "$INPUT")" in
+    *musl*)  PLATFORM=musl ;;
+    *linux*) PLATFORM=linux ;;
+    *mac*)   PLATFORM=mac ;;
+    *)       echo "Error: cannot infer platform from $INPUT (pass explicitly)" >&2; exit 2 ;;
+  esac
+fi
+
+case "$PLATFORM" in
+  linux|musl|mac) ;;
+  *) echo "Error: unknown platform '$PLATFORM'" >&2; exit 2 ;;
+esac
+
+# If given a .tgz, extract to a temp dir and operate on its lib/ contents.
+WORK=""
+cleanup() { [ -n "$WORK" ] && rm -rf "$WORK"; }
+trap cleanup EXIT
+
+if [ -f "$INPUT" ] && [[ "$INPUT" == *.tgz || "$INPUT" == *.tar.gz ]]; then
+  WORK=$(mktemp -d)
+  tar xzf "$INPUT" -C "$WORK"
+  LIB_DIR=$(find "$WORK" -type d -name lib | head -n1)
+  if [ -z "$LIB_DIR" ]; then
+    echo "Error: no lib/ directory in $INPUT" >&2
+    exit 2
+  fi
+else
+  LIB_DIR=$(dirname "$INPUT")
+fi
+
+echo "Verifying archive for platform=$PLATFORM at $LIB_DIR"
+
+# ---------------------------------------------------------------------------
+# Symbol-listing helper: returns demangled C++ symbols, one per line.
+# Linux: nm -C works directly. Mac: Apple's nm has no -C, pipe via c++filt.
+# ---------------------------------------------------------------------------
+list_symbols() {
+  local file="$1"
+  if [ "$PLATFORM" = "mac" ]; then
+    # -g: global/external; we want everything, not just -U defined.
+    nm "$file" 2>/dev/null | c++filt
+  else
+    nm -C "$file" 2>/dev/null
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Invariant checks
+# ---------------------------------------------------------------------------
+
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=1
+}
+
+verify_lib() {
+  local lib="$1"
+  echo "---- $lib ----"
+
+  # Dump symbols to a temp file, then grep the file directly. This
+  # avoids the `echo "$syms" | grep -q ...` + `set -o pipefail` trap:
+  # when grep -q matches early it closes the pipe, echo gets SIGPIPE,
+  # and the pipeline exit status flips nonzero — `if ! ...` then fires
+  # `fail` on a successful match. libpdfium.a's symbol list is large
+  # enough (thousands of archive members) that echo has not finished
+  # writing when grep finds its match, so every linux .a reported
+  # every invariant as failing until we moved to file-based grep.
+  local syms_file
+  syms_file=$(mktemp)
+  # shellcheck disable=SC2064  # intentional $syms_file expansion at trap-setup time
+  trap "rm -f '$syms_file'" RETURN
+  list_symbols "$lib" > "$syms_file"
+
+  # Catch silent nm failure (would cause every grep to pass vacuously).
+  if [ ! -s "$syms_file" ]; then
+    fail "nm produced no output for $lib"
+    return
+  fi
+
+  # 1. Public FPDF_* C API must be defined. This invariant applies to
+  #    every shippable artifact — both rustc static links and dlopen
+  #    consumers call into the public C entry points.
+  #
+  # Match "<space-or-underscore>SYM<end-of-line>": mac's mach-o nm
+  # prefixes C symbols with `_` (so the line ends in `_FPDF_InitLibrary`)
+  # while linux/musl ELF nm does not (line ends in `FPDF_InitLibrary`).
+  # A `\b` word boundary fails on mac because `_` and `F` are both word
+  # characters, so there's no boundary between them.
+  for sym in FPDF_InitLibrary FPDF_DestroyLibrary FPDF_LoadDocument; do
+    if ! grep -qE "[ _]${sym}$" "$syms_file"; then
+      fail "$lib missing required symbol: $sym"
+    fi
+  done
+
+  # Static vs shared invariants diverge from here:
+  #
+  #   * libpdfium.a is linked by rustc at build time — every internal C++
+  #     symbol must be resolvable against the consumer's system C++ runtime.
+  #     Chromium's bundled libc++ (std::__Cr::*) does not exist on the
+  #     consumer side; the link fails with "undefined reference to
+  #     std::__Cr::basic_string<...>". So .a MUST NOT contain __Cr::
+  #     symbols, and MUST contain the platform's standard C++ runtime
+  #     namespace (std::__cxx11:: on linux, std::__1:: on mac).
+  #
+  #   * libpdfium.so / libpdfium.dylib are loaded at runtime via dlopen —
+  #     internal C++ symbols are fully resolved inside the library itself.
+  #     Chromium's self-contained __Cr::* symbols are therefore harmless
+  #     in the shared object, and keeping them lets the linux shared build
+  #     continue to use Chromium's bundled sysroot for arm64 cross-compile
+  #     (which ships glib/nss/fontconfig the system apt can't provide
+  #     multi-arch). We only verify the public C API for .so/.dylib.
+  case "$lib" in
+    *.a)
+      local cr_count
+      cr_count=$(grep -c '__Cr::' "$syms_file" || true)
+      if [ "$cr_count" -gt 0 ]; then
+        fail "$lib contains $cr_count std::__Cr::* symbols (Chromium custom libc++ leaked into static archive)"
+        echo "  first few:" >&2
+        # head closes the pipe early; `|| true` keeps pipefail from
+        # promoting that SIGPIPE into a hard exit under `set -e`.
+        grep '__Cr::' "$syms_file" | head -3 >&2 || true
+      fi
+
+      if [ "$PLATFORM" = "mac" ]; then
+        # Apple libc++ inline namespace.
+        if ! grep -q 'std::__1::' "$syms_file"; then
+          fail "$lib has no std::__1:: symbols — Apple libc++ not linked?"
+        fi
+      else
+        # libstdc++ dual-ABI inline namespace.
+        if ! grep -q 'std::__cxx11::' "$syms_file"; then
+          fail "$lib has no std::__cxx11:: symbols — libstdc++ not linked?"
+        fi
+      fi
+      ;;
+    *.so|*.dylib)
+      # Public C API check above is sufficient; internal __Cr:: symbols
+      # are acceptable because they are resolved within the shared object
+      # and never surfaced to dlopen consumers.
+      ;;
+    *)
+      fail "$lib has unexpected extension (expected .a, .so, or .dylib)"
+      ;;
+  esac
+}
+
+# Find all shippable libs in LIB_DIR (may include .a, .so, .dylib).
+shopt -s nullglob
+LIBS=()
+for f in "$LIB_DIR"/libpdfium.a "$LIB_DIR"/libpdfium.so "$LIB_DIR"/libpdfium.dylib; do
+  [ -e "$f" ] && LIBS+=("$f")
+done
+shopt -u nullglob
+
+if [ "${#LIBS[@]}" -eq 0 ]; then
+  echo "Error: no libpdfium.{a,so,dylib} found under $LIB_DIR" >&2
+  exit 2
+fi
+
+for lib in "${LIBS[@]}"; do
+  verify_lib "$lib"
+done
+
+if [ $FAIL -ne 0 ]; then
+  echo ""
+  echo "verify_archive.sh: one or more invariants failed (see FAIL lines above)" >&2
+  exit 1
+fi
+
+echo ""
+echo "verify_archive.sh: all invariants hold — archive is rustc-linkable."

--- a/pdfium/tests/test_dockerfile.py
+++ b/pdfium/tests/test_dockerfile.py
@@ -66,6 +66,48 @@ class TestMakeDockerfileLinuxAmd64:
         assert "pdf_use_partition_alloc = false" in self.df
         assert "clang_use_chrome_plugins = false" in self.df
 
+    def test_libcxx_standard_in_static_args_only(self):
+        # Rust consumers of libpdfium.a (via pdfium-render/static with the
+        # libstdc++ feature) link against the system C++ runtime and
+        # cannot resolve Chromium's std::__Cr::* symbols. The static pass
+        # therefore disables Chromium's bundled libc++ — but ONLY the
+        # static pass: the shared build on linux/arm64 cross-compile
+        # relies on the bundled sysroot (via use_custom_libcxx=true /
+        # use_sysroot=true) for arm64 glib/nss/fontconfig. dlopen
+        # consumers of libpdfium.so never resolve internal C++ symbols,
+        # so keeping __Cr::* in the .so is harmless.
+        static_args_pos = self.df.index("out/Static/args.gn")
+        shared_args_pos = self.df.index("out/Shared/args.gn")
+        libcxx_false_pos = self.df.index("use_custom_libcxx = false")
+        # libcxx=false appears in the static heredoc, between the two markers.
+        assert static_args_pos < libcxx_false_pos < shared_args_pos, (
+            "use_custom_libcxx = false must live inside the Static args heredoc "
+            "only, not the Shared one"
+        )
+        # Must appear exactly once in the entire Dockerfile: if it leaked
+        # into the shared heredoc, linux/arm64 cross-compile SOLINK would
+        # fail with "unable to find library -lglib-2.0".
+        assert self.df.count("use_custom_libcxx = false") == 1
+        assert "use_custom_libcxx_for_host = false" in self.df
+
+    def test_shared_build_keeps_custom_libcxx(self):
+        # The shared build on linux MUST keep use_custom_libcxx = true —
+        # the bundled sysroot is the only source of arm64 glib, nss, and
+        # fontconfig for cross-compile.
+        assert "use_custom_libcxx = true" in self.df
+
+    def test_use_sysroot_false_in_static_args_only(self):
+        # Pairs with use_custom_libcxx = false: Chromium's debian_bookworm
+        # sysroot lacks libstdc++ headers, so the static build uses host
+        # system headers (libstdc++-12-dev via build-essential) instead.
+        # The shared build keeps the default use_sysroot = true so arm64
+        # cross-compile can link against the sysroot's bundled glib.
+        static_args_pos = self.df.index("out/Static/args.gn")
+        shared_args_pos = self.df.index("out/Shared/args.gn")
+        flag_pos = self.df.index("use_sysroot = false")
+        assert static_args_pos < flag_pos < shared_args_pos
+        assert self.df.count("use_sysroot = false") == 1
+
     def test_two_ninja_invocations(self):
         assert "ninja -C out/Static pdfium" in self.df
         assert "ninja -C out/Shared pdfium" in self.df
@@ -144,6 +186,26 @@ class TestMakeDockerfileLinuxArm64:
         assert "ninja -C out/Static pdfium" in self.df
         assert "ninja -C out/Shared pdfium" in self.df
 
+    def test_libcxx_standard_in_static_args_only(self):
+        # Same scoping as linux/amd64: static gets standard libstdc++
+        # symbols, shared keeps Chromium's bundled libc++ + sysroot so
+        # SOLINK can resolve the bundled arm64 glib/nss/fontconfig.
+        static_args_pos = self.df.index("out/Static/args.gn")
+        shared_args_pos = self.df.index("out/Shared/args.gn")
+        libcxx_false_pos = self.df.index("use_custom_libcxx = false")
+        assert static_args_pos < libcxx_false_pos < shared_args_pos
+        assert self.df.count("use_custom_libcxx = false") == 1
+
+    def test_shared_build_keeps_custom_libcxx(self):
+        assert "use_custom_libcxx = true" in self.df
+
+    def test_use_sysroot_false_in_static_args_only(self):
+        static_args_pos = self.df.index("out/Static/args.gn")
+        shared_args_pos = self.df.index("out/Shared/args.gn")
+        flag_pos = self.df.index("use_sysroot = false")
+        assert static_args_pos < flag_pos < shared_args_pos
+        assert self.df.count("use_sysroot = false") == 1
+
 
 class TestMakeDockerfileMuslAmd64:
     def setup_method(self):
@@ -221,6 +283,14 @@ class TestMakeDockerfileMuslAmd64:
     def test_pdf_is_complete_lib_not_in_shared_args(self):
         assert self.df.count("pdf_is_complete_lib = true") == 1
 
+    def test_libcxx_standard_not_custom(self):
+        # musl already uses libstdc++ (gcc + musl-cross-make ships its own
+        # libstdc++.a); this regression-guards both the libcxx and the
+        # for_host flag remaining disabled.
+        assert "use_custom_libcxx = false" in self.df
+        assert "use_custom_libcxx_for_host = false" in self.df
+        assert "use_custom_libcxx = true" not in self.df
+
 
 class TestMakeDockerfileMuslArm64:
     def setup_method(self):
@@ -231,6 +301,11 @@ class TestMakeDockerfileMuslArm64:
 
     def test_target_cpu_arm64(self):
         assert 'target_cpu = "arm64"' in self.df
+
+    def test_libcxx_standard_not_custom(self):
+        assert "use_custom_libcxx = false" in self.df
+        assert "use_custom_libcxx_for_host = false" in self.df
+        assert "use_custom_libcxx = true" not in self.df
 
 
 class TestMakeDockerfileDifferentVersions:

--- a/pdfium/tests/test_mac_build_script.py
+++ b/pdfium/tests/test_mac_build_script.py
@@ -1,0 +1,73 @@
+"""Tests for pdfium/build_mac_native.sh.
+
+The mac build runs on a macos-15 GitHub Actions runner (instead of inside
+the Debian build container used for linux/musl) because PDFium's
+``gn gen`` invokes ``xcodebuild``, which doesn't exist in Docker. This
+native build path writes its own ``out/Release/args.gn`` heredoc.
+
+Currently this script only produces a ``libpdfium.dylib`` — a single
+shared-library phase. Internal C++ symbols are resolved inside the
+dylib itself before any ``dlopen`` consumer sees them, so Chromium's
+bundled libc++ (``use_custom_libcxx = true``, the default) is fine and
+we intentionally do *not* override it. This matches the linux .so path
+in ``build_pdfium.py``: libcxx overrides are scoped to the static
+archive only, because rustc is the single consumer that actually links
+against internal C++ symbols and can't resolve ``std::__Cr::``.
+
+Setting ``use_custom_libcxx = false`` here additionally broke on
+Xcode 26.0 / MacOSX26.0.sdk (Chromium's libc++ module sources expect
+macros that are only defined when the bundled libc++ is active).
+"""
+
+import os
+import re
+
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "..", "build_mac_native.sh")
+
+
+def load_script():
+    with open(SCRIPT_PATH) as f:
+        return f.read()
+
+
+def extract_args_gn_heredoc(sh: str) -> str:
+    # Pull just the `cat > out/Release/args.gn <<EOF ... EOF` block so
+    # assertions test what actually ends up in args.gn, not commentary
+    # in surrounding shell comments.
+    m = re.search(r"cat > out/Release/args\.gn <<EOF\n(.*?)\nEOF\n", sh, re.DOTALL)
+    assert m, "args.gn heredoc not found in build_mac_native.sh"
+    return m.group(1)
+
+
+class TestMacBuildScriptLibcxx:
+    def setup_method(self):
+        self.args_gn = extract_args_gn_heredoc(load_script())
+
+    def test_dylib_keeps_chromium_bundled_libcxx(self):
+        # mac dylib is shared-only — dlopen consumers never see internal
+        # __Cr:: symbols, so Chromium's bundled libc++ is harmless and we
+        # MUST NOT set use_custom_libcxx = false here. Doing so broke the
+        # Xcode 26.0 build with module compile errors in Chromium's own
+        # libc++ sources. If a mac static build is added later it needs
+        # its own out/Static args.gn with the override isolated there —
+        # see build_pdfium.py's gn_args_static_for() for the linux
+        # pattern.
+        assert "use_custom_libcxx = false" not in self.args_gn
+        assert "use_custom_libcxx_for_host" not in self.args_gn
+
+
+class TestMacBuildScriptXcodePin:
+    def setup_method(self):
+        self.sh = load_script()
+
+    def test_xcode_pin_present(self):
+        # Regression guard for PR #19's Xcode 26.0 pin — MacOSX15.5.sdk
+        # (Xcode 16.4 default) removes DarwinFoundation1.modulemap which
+        # PDFium 7725's ninja graph still references.
+        assert "Xcode_26.0.app" in self.sh
+
+    def test_xcode_pin_exported_via_developer_dir(self):
+        # Use DEVELOPER_DIR rather than `sudo xcode-select -s` so the
+        # script is safe to run locally without modifying the
+        # developer's global toolchain.
+        assert "export DEVELOPER_DIR=" in self.sh

--- a/pdfium/tests/test_release_workflow.py
+++ b/pdfium/tests/test_release_workflow.py
@@ -1,0 +1,179 @@
+"""Tests for .github/workflows/release.yml.
+
+The release workflow publishes every archive in the default build matrix
+to a GitHub Release. Symbol verification (``pdfium/scripts/verify_archive.sh``)
+must run AFTER each build and BEFORE the matching upload, so a bad archive
+can never reach the Release page. These tests lock that ordering in.
+"""
+
+import os
+import re
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+
+WORKFLOW_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    ".github",
+    "workflows",
+    "release.yml",
+)
+
+
+def load_workflow():
+    with open(WORKFLOW_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def step_names(job):
+    return [s.get("name", "") for s in job.get("steps", [])]
+
+
+def step_index(job, name_substr):
+    for i, s in enumerate(job.get("steps", [])):
+        if name_substr.lower() in s.get("name", "").lower():
+            return i
+    return -1
+
+
+class TestReleaseWorkflowShape:
+    def setup_method(self):
+        self.wf = load_workflow()
+
+    def test_workflow_parses(self):
+        assert self.wf["name"] == "Release"
+
+    def test_build_linux_job_exists(self):
+        assert "build-linux" in self.wf["jobs"]
+
+    def test_build_mac_job_exists(self):
+        assert "build-mac" in self.wf["jobs"]
+
+
+class TestBuildLinuxVerifyStep:
+    """build-linux must build, verify, then upload — in that order."""
+
+    def setup_method(self):
+        self.wf = load_workflow()
+        self.job = self.wf["jobs"]["build-linux"]
+
+    def test_verify_step_present(self):
+        names = step_names(self.job)
+        assert any("verify" in n.lower() for n in names), (
+            f"build-linux is missing a verify step; steps were: {names}"
+        )
+
+    def test_verify_after_build(self):
+        build_i = step_index(self.job, "Build")
+        verify_i = step_index(self.job, "Verify")
+        assert build_i >= 0, "no Build step found"
+        assert verify_i >= 0, "no Verify step found"
+        assert verify_i > build_i, (
+            "Verify must run AFTER Build — otherwise there's nothing to verify"
+        )
+
+    def test_verify_before_upload(self):
+        verify_i = step_index(self.job, "Verify")
+        upload_i = step_index(self.job, "Upload release")
+        assert verify_i >= 0, "no Verify step found"
+        assert upload_i >= 0, (
+            "no 'Upload release' step found — build_pdfium.py --upload was "
+            "expected to be split into separate Build + Upload steps so "
+            "Verify can gate the upload"
+        )
+        assert verify_i < upload_i, (
+            "Verify must run BEFORE the release upload — otherwise a bad "
+            "archive reaches the Release page before we reject it"
+        )
+
+    def test_build_step_does_not_upload(self):
+        """--upload must not run as part of the Build step, or verification is pointless."""
+        steps = self.job["steps"]
+        build_i = step_index(self.job, "Build")
+        assert build_i >= 0
+        run = steps[build_i].get("run", "")
+        assert "--upload" not in run, (
+            "Build step must NOT pass --upload; upload must be a separate "
+            "step that runs only after Verify succeeds"
+        )
+
+    def test_verify_invokes_verify_script(self):
+        steps = self.job["steps"]
+        verify_i = step_index(self.job, "Verify")
+        run = steps[verify_i].get("run", "")
+        assert "verify_archive.sh" in run, f"Verify step must invoke verify_archive.sh; got:\n{run}"
+
+
+class TestBuildMacVerifyStep:
+    """build-mac must build, verify, then upload — same invariants as linux."""
+
+    def setup_method(self):
+        self.wf = load_workflow()
+        self.job = self.wf["jobs"]["build-mac"]
+
+    def test_verify_step_present(self):
+        names = step_names(self.job)
+        assert any("verify" in n.lower() for n in names), (
+            f"build-mac is missing a verify step; steps were: {names}"
+        )
+
+    def test_verify_after_build_before_upload(self):
+        build_i = step_index(self.job, "Build")
+        verify_i = step_index(self.job, "Verify")
+        upload_i = step_index(self.job, "Upload release")
+        assert 0 <= build_i < verify_i < upload_i, (
+            f"expected Build < Verify < Upload, got indices {build_i}/{verify_i}/{upload_i}"
+        )
+
+    def test_verify_invokes_verify_script(self):
+        steps = self.job["steps"]
+        verify_i = step_index(self.job, "Verify")
+        run = steps[verify_i].get("run", "")
+        assert "verify_archive.sh" in run
+
+
+class TestBuildMacUniversalVerify:
+    """The lipo'd universal dylib is a distinct artifact — it also must be
+    verified before upload, because the fusing step could theoretically
+    introduce symbol mismatches (it won't in practice, but belt + braces
+    catches any future regression in our lipo invocation)."""
+
+    def setup_method(self):
+        self.wf = load_workflow()
+        self.job = self.wf["jobs"]["build-mac-universal"]
+
+    def test_verify_step_present(self):
+        names = step_names(self.job)
+        assert any("verify" in n.lower() for n in names), (
+            f"build-mac-universal is missing a verify step; steps were: {names}"
+        )
+
+    def test_verify_before_upload(self):
+        verify_i = step_index(self.job, "Verify")
+        upload_i = step_index(self.job, "Upload")
+        assert verify_i >= 0 and upload_i >= 0
+        assert verify_i < upload_i
+
+
+class TestVerifyScriptShellReference:
+    """The path passed to verify_archive.sh must match what build_pdfium.py
+    actually writes to --output-dir. Guards against drift between
+    archive_name() in build_pdfium.py and the workflow."""
+
+    def setup_method(self):
+        self.wf = load_workflow()
+
+    def test_linux_verify_uses_bin_glob_or_explicit_tgz(self):
+        job = self.wf["jobs"]["build-linux"]
+        steps = job["steps"]
+        verify_i = step_index(job, "Verify")
+        run = steps[verify_i].get("run", "")
+        # Either a glob matching build_pdfium.py's default output-dir, or
+        # an explicit filename derived from the matrix vars.
+        assert re.search(r"bin[/\\].*\.tgz", run) or "pdfium-" in run, (
+            f"Verify step should reference bin/*.tgz or pdfium-<plat>-<arch>.tgz; got:\n{run}"
+        )

--- a/pdfium/tests/test_verify_archive_script.py
+++ b/pdfium/tests/test_verify_archive_script.py
@@ -1,0 +1,190 @@
+"""Tests for pdfium/scripts/verify_archive.sh.
+
+The verify script runs at the end of every release build job (and
+locally during development). It inspects the just-built libpdfium.a /
+libpdfium.so / libpdfium.dylib and fails the build if any of these
+invariants break:
+
+  * required FPDF_* C API symbols are present (public ABI not stripped).
+  * in libpdfium.a: std::__Cr:: symbols are absent (no Chromium custom
+    libc++ leaked — rustc consumers can't resolve __Cr).
+  * in libpdfium.a on linux: std::__cxx11:: libstdc++ symbols present.
+  * in libpdfium.a on macOS: std::__1:: Apple libc++ symbols present.
+  * .so and .dylib files are checked ONLY for the public FPDF_* API —
+    __Cr:: is acceptable there because dlopen consumers never see it.
+
+These tests cover script-level invariants (existence, executability,
+shellcheck-cleanliness, argument handling). Full symbol verification is
+exercised end-to-end in the release workflow against real .tgz files.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "..", "scripts", "verify_archive.sh")
+
+
+class TestVerifyArchiveScriptShape:
+    def test_script_exists(self):
+        assert os.path.exists(SCRIPT_PATH), f"verify script missing at {SCRIPT_PATH}"
+
+    def test_script_is_executable(self):
+        mode = os.stat(SCRIPT_PATH).st_mode
+        assert mode & stat.S_IXUSR, "script must have user-execute bit set"
+
+    def test_script_has_shebang(self):
+        with open(SCRIPT_PATH) as f:
+            first = f.readline().rstrip()
+        assert first.startswith("#!"), f"missing shebang, got: {first!r}"
+        assert "bash" in first
+
+    def test_script_uses_strict_mode(self):
+        with open(SCRIPT_PATH) as f:
+            text = f.read()
+        assert "set -euo pipefail" in text, (
+            "verify script must use strict mode; a silent tool miss would let a bad archive ship"
+        )
+
+
+class TestVerifyArchiveScriptContent:
+    def setup_method(self):
+        with open(SCRIPT_PATH) as f:
+            self.sh = f.read()
+
+    def test_forbids_chromium_cr_namespace(self):
+        # This is the core invariant — every consumer of this script
+        # relies on the Chromium __Cr namespace being rejected.
+        assert "__Cr::" in self.sh
+
+    def test_requires_fpdf_init_library(self):
+        # FPDF_InitLibrary is the canonical entry point; if the public
+        # FPDF_* C API was stripped, downstream builds link-fail.
+        assert "FPDF_InitLibrary" in self.sh
+
+    def test_mac_uses_cxxfilt_fallback(self):
+        # Apple's nm(1) does not support -C; the script must demangle
+        # via `c++filt` on mac. Linux nm -C works directly.
+        assert "c++filt" in self.sh
+
+    def test_linux_expects_cxx11_std(self):
+        # libstdc++'s dual-ABI inline namespace — the presence of this
+        # namespace in demangled symbols proves we're on libstdc++ and
+        # not libc++.
+        assert "__cxx11" in self.sh
+
+    def test_mac_expects_libcxx_std(self):
+        # Apple libc++ inline namespace — the mac "standard" namespace.
+        assert "__1::" in self.sh or "__1\\\\:\\\\:" in self.sh
+
+    def test_cr_namespace_strict_only_for_static_archive(self):
+        # Chromium's std::__Cr::* is only toxic for .a consumers (rustc
+        # links against the system C++ runtime and can't resolve __Cr).
+        # For .so/.dylib, __Cr symbols are internal to the dynamic
+        # library and dlopen consumers never see them, so those libs
+        # are allowed to keep Chromium's bundled libc++ — which is what
+        # the linux shared build actually does (use_custom_libcxx=true
+        # is needed on linux/arm64 for the sysroot's bundled glib).
+        assert "*.a)" in self.sh, (
+            "verify_archive.sh must dispatch on *.a separately so the "
+            "__Cr:: check only applies to the static archive"
+        )
+        assert "*.so|*.dylib)" in self.sh or "*.so)" in self.sh, (
+            "verify_archive.sh must also dispatch on .so/.dylib so those "
+            "artifacts are allowed to keep internal __Cr:: symbols"
+        )
+
+
+class TestVerifyArchiveScriptShellcheck:
+    def test_passes_shellcheck(self):
+        if not shutil.which("shellcheck"):
+            # Mirror existing conftest pattern: skip if tool unavailable
+            # rather than fail the test run. CI has shellcheck pinned.
+            import pytest
+
+            pytest.skip("shellcheck not installed on this host")
+        result = subprocess.run(
+            ["shellcheck", SCRIPT_PATH],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, f"shellcheck failed:\n{result.stdout}\n{result.stderr}"
+
+
+class TestVerifyArchiveScriptMachOSymbolMatch:
+    def setup_method(self):
+        with open(SCRIPT_PATH) as f:
+            self.sh = f.read()
+
+    def test_fpdf_regex_tolerates_mach_o_underscore_prefix(self):
+        # On mac, mach-o nm prefixes C symbols with `_`, so a real line
+        # looks like:
+        #     0000000000012ab0 T _FPDF_InitLibrary
+        # A `\b` word boundary between `_` and `F` does NOT exist (both
+        # are word chars), so the original `\bFPDF_InitLibrary\b` pattern
+        # silently reported every mac dylib as missing its public C API.
+        # Pin the fix: the FPDF_* match must accept either whitespace or
+        # underscore before the symbol name.
+        import re as _re
+
+        match = _re.search(r'grep -qE "\[([^\]]+)\]\$\{sym\}\$"', self.sh)
+        assert match, "FPDF_* regex pattern not found in verify script"
+        charclass = match.group(1)
+        assert "_" in charclass, (
+            f"FPDF_* regex char class {charclass!r} must include `_` to "
+            "match mac mach-o underscore-prefixed symbols"
+        )
+        assert " " in charclass, (
+            f"FPDF_* regex char class {charclass!r} must include ` ` to "
+            "match linux/musl ELF symbols (no prefix)"
+        )
+
+
+class TestVerifyArchiveScriptPipefailSafety:
+    def setup_method(self):
+        import re as _re
+
+        with open(SCRIPT_PATH) as f:
+            raw = f.read()
+        # Drop shell comments and blank lines so assertions only match
+        # executable code, not explanatory prose that quotes the
+        # forbidden pattern.
+        self.code = "\n".join(
+            line for line in raw.splitlines() if not _re.match(r"\s*#", line) and line.strip()
+        )
+
+    def test_symbol_checks_do_not_pipe_echo_to_grep(self):
+        # Under `set -o pipefail`, `echo "$syms" | grep -q …` fails the
+        # whole pipeline when grep matches early and echo gets SIGPIPE
+        # on a subsequent write. That false-fails every invariant on
+        # linux .a (the archive's symbol list is big enough that echo
+        # never finishes before grep exits). Dump symbols to a tempfile
+        # and grep the file instead.
+        assert 'echo "$syms" | grep' not in self.code, (
+            "verify_archive.sh must not pipe $syms into grep — pipefail "
+            "promotes echo's SIGPIPE to a pipeline failure. Write to a "
+            "temp file and grep the file."
+        )
+
+    def test_symbol_dump_goes_to_temp_file(self):
+        # Encode the chosen mitigation so a future refactor can't silently
+        # re-introduce the pipe form.
+        assert "mktemp" in self.code
+        assert "syms_file" in self.code
+
+
+class TestVerifyArchiveScriptUsage:
+    def test_fails_without_argument(self):
+        # If invoked with no archive path, the script must exit non-zero
+        # with a usage message — never succeed silently.
+        result = subprocess.run(
+            ["bash", SCRIPT_PATH],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode != 0
+        combined = (result.stdout + result.stderr).lower()
+        assert "usage" in combined or "missing" in combined


### PR DESCRIPTION
## Summary

Promote main → release to publish \`pdfium-7725\` archives via the release workflow. This release includes PR #21's static-archive fix (libpdfium.a now links from rustc against the system C++ runtime), the new \`verify_archive.sh\` CI gate, the \`build.yml\` mac-runner + output-path fixes, and the mach-o / pipefail regression fixes surfaced while validating.

## Release contents

- Linux amd64 + arm64: \`libpdfium.so\` + \`libpdfium.a\`
- Musl amd64 + arm64: \`libpdfium.so\` + \`libpdfium.a\`
- Mac arm64: \`libpdfium.dylib\` (static \`.a\` for mac tracked in #22)

All artifacts pass the \`verify_archive.sh\` invariants:
- Public \`FPDF_*\` C API present.
- No \`std::__Cr::*\` in the static archives (Chromium custom libc++ contained).
- Platform-standard C++ runtime linked into the static archive (\`std::__cxx11::\` on linux/musl, \`std::__1::\` on mac).

## Test plan
- [x] PR #21 CI green (4/4 checks)
- [x] build.yml workflow_dispatch green (5/5 matrix combos, run 24704121099)
- [x] libviprs + libviprs-tests integration suite green against freshly-built linux-amd64 libpdfium.so
- [ ] release.yml fires on merge, publishes \`pdfium-7725\` tag with all 5 archives