### PR TITLE
pdfium(musl): absolute toolchain paths for ar/nm/readelf (fix static build)

### DIFF
--- a/pdfium/patches/musl.py
+++ b/pdfium/patches/musl.py
@@ -163,9 +163,9 @@ gcc_toolchain("x86") {
   cc = "${toolprefix}gcc"
   cxx = "${toolprefix}g++"
 
-  readelf = "${toolprefix}readelf"
-  nm = "${toolprefix}nm"
-  ar = "${toolprefix}ar"
+  readelf = "/opt/${toolprefix}cross/bin/${toolprefix}readelf"
+  nm = "/opt/${toolprefix}cross/bin/${toolprefix}nm"
+  ar = "/opt/${toolprefix}cross/bin/${toolprefix}ar"
   ld = cxx
 
   extra_ldflags = "-static-libgcc -static-libstdc++"
@@ -185,9 +185,9 @@ gcc_toolchain("x64") {
   cc = "${toolprefix}gcc"
   cxx = "${toolprefix}g++"
 
-  readelf = "${toolprefix}readelf"
-  nm = "${toolprefix}nm"
-  ar = "${toolprefix}ar"
+  readelf = "/opt/${toolprefix}cross/bin/${toolprefix}readelf"
+  nm = "/opt/${toolprefix}cross/bin/${toolprefix}nm"
+  ar = "/opt/${toolprefix}cross/bin/${toolprefix}ar"
   ld = cxx
 
   extra_ldflags = "-static-libgcc -static-libstdc++"
@@ -207,9 +207,9 @@ gcc_toolchain("arm") {
   cc = "${toolprefix}gcc"
   cxx = "${toolprefix}g++"
 
-  readelf = "${toolprefix}readelf"
-  nm = "${toolprefix}nm"
-  ar = "${toolprefix}ar"
+  readelf = "/opt/${toolprefix}cross/bin/${toolprefix}readelf"
+  nm = "/opt/${toolprefix}cross/bin/${toolprefix}nm"
+  ar = "/opt/${toolprefix}cross/bin/${toolprefix}ar"
   ld = cxx
 
   extra_ldflags = "-static-libgcc -static-libstdc++"
@@ -229,9 +229,9 @@ gcc_toolchain("arm64") {
   cc = "${toolprefix}gcc"
   cxx = "${toolprefix}g++"
 
-  readelf = "${toolprefix}readelf"
-  nm = "${toolprefix}nm"
-  ar = "${toolprefix}ar"
+  readelf = "/opt/${toolprefix}cross/bin/${toolprefix}readelf"
+  nm = "/opt/${toolprefix}cross/bin/${toolprefix}nm"
+  ar = "/opt/${toolprefix}cross/bin/${toolprefix}ar"
   ld = cxx
 
   extra_cxxflags= "-flax-vector-conversions"


### PR DESCRIPTION
Fixes the musl static-archive failure in the pdfium-7881 release run (both amd64 and arm64): `ninja -C out/Static` couldn't resolve the bare `<arch>-linux-musl-ar`. Uses absolute paths into the installed toolchain bin (`/opt/<target>-cross/bin`). Linux/mac builds were unaffected. Merging re-triggers the release build.