### PR TITLE
feat(pdfium): build libpdfium.a for mac + verify static archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,8 @@ jobs:
             if [ "${{ matrix.platform }}" = "mac" ]; then
               tar tzf "$f" | grep -q 'lib/libpdfium.dylib' \
                 || { echo "missing libpdfium.dylib in $f"; exit 1; }
+              tar tzf "$f" | grep -q 'lib/libpdfium.a' \
+                || { echo "missing libpdfium.a in $f";  exit 1; }
             else
               tar tzf "$f" | grep -q 'lib/libpdfium.so' \
                 || { echo "missing libpdfium.so in $f"; exit 1; }

--- a/pdfium/README.md
+++ b/pdfium/README.md
@@ -29,7 +29,7 @@ https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-mu
 | --- | --- | --- |
 | `linux-x64`, `linux-arm64` | glibc | Debian, Ubuntu, RHEL, most mainstream distros |
 | `musl-x64`, `musl-arm64`   | musl  | Alpine, any container built `FROM alpine:*`, musl-based distroless images |
-| `mac-arm64`                | —     | macOS 11+ on Apple Silicon (`libpdfium.dylib`) |
+| `mac-arm64`                | —     | macOS 11+ on Apple Silicon (`libpdfium.dylib` + `libpdfium.a`) |
 | `mac-x64`                  | —     | macOS 11+ on Intel (`libpdfium.dylib`) |
 | `mac-univ`                 | —     | macOS 11+ on both Apple Silicon and Intel — universal Mach-O combining the arm64 + x64 dylibs via `lipo -create` |
 
@@ -272,7 +272,7 @@ Platform-specific patches live in `patches/<platform>.py`. The `--platform` flag
 ```
 patches/
   linux.py     # glibc linux shared library patches
-  mac.py       # macOS shared library patches (single-phase today)
+  mac.py       # macOS patches: base (fpdfview + headerpad) then shared (component -> shared_library)
   musl.py      # musl/Alpine patches + toolchain install
 ```
 

--- a/pdfium/build_mac_native.sh
+++ b/pdfium/build_mac_native.sh
@@ -41,7 +41,7 @@ DIR_NAME="pdfium-mac-${GN_CPU}"
 STAGE_DEST="$STAGING/$DIR_NAME"
 ARCHIVE="$OUTPUT_DIR/$DIR_NAME.tgz"
 
-TOTAL=10
+TOTAL=14
 
 mkdir -p "$WORKSPACE" "$OUTPUT_DIR"
 rm -rf "$BUILD_DIR" "$STAGING" "$ARCHIVE"
@@ -103,26 +103,100 @@ echo "[5/$TOTAL] gclient runhooks"
 cd "$PDFIUM"
 gclient runhooks
 
-echo "[6/$TOTAL] Apply mac patches"
-# mac builds are single-phase (.dylib only), so --mode all is fine.
-python3 "$REPO_ROOT/pdfium/patches/mac.py" "$PDFIUM" --mode all
+echo "[6/$TOTAL] Apply mac base patches"
+# Two-phase build (mirrors the linux/musl path in build_pdfium.py): the
+# base patches (fpdfview.h symbol visibility + Apple toolchain headerpad)
+# apply to BOTH the static archive and the dylib. The BUILD.gn
+# component()->shared_library rewrite is deferred to the shared pass
+# (step 10) so the Static pass keeps the pristine component("pdfium"),
+# which resolves to a static_library once pdf_is_complete_lib = true
+# fires PDFium's own fat-archive branch.
+python3 "$REPO_ROOT/pdfium/patches/mac.py" "$PDFIUM" --mode base
 
-echo "[7/$TOTAL] gn gen"
+echo "[7/$TOTAL] gn gen out/Static (libpdfium.a)"
+# The libc++ override is SCOPED TO out/Static ONLY:
+#   pdf_is_complete_lib = true         -> PDFium's own BUILD.gn branch
+#     emits a fat static_library (drops the //build/config/compiler:
+#     thin_archive config) instead of a GNU thin archive, whose absolute
+#     .o paths vanish when the build dir is cleaned and would break
+#     rustc's rlib bundling downstream.
+#   use_custom_libcxx = false          -> link Apple's system libc++
+#   use_custom_libcxx_for_host = false    (inline namespace std::__1::) so
+#     rustc can resolve PDFium's internal C++ symbols against the system
+#     runtime rather than Chromium's std::__Cr:: bundled libc++.
+# This override MUST NOT leak into out/Release (the dylib): see the
+# out/Release comment below for why it re-breaks the Xcode 26.0 build.
+mkdir -p out/Static
+cat > out/Static/args.gn <<EOF
+is_debug = false
+pdf_is_standalone = true
+pdf_enable_v8 = false
+pdf_enable_xfa = false
+is_component_build = false
+treat_warnings_as_errors = false
+pdf_use_skia = false
+pdf_use_partition_alloc = false
+clang_use_chrome_plugins = false
+target_cpu = "$GN_CPU"
+target_os = "mac"
+pdf_is_complete_lib = true
+use_custom_libcxx = false
+use_custom_libcxx_for_host = false
+EOF
+gn gen out/Static
+
+echo "[8/$TOTAL] ninja -C out/Static pdfium"
+ninja -C out/Static pdfium
+
+echo "[9/$TOTAL] Verify libpdfium.a is a complete (fat) static archive"
+# Mirror build_pdfium.py's VERIFY_COMPLETE_STATIC_LIB gate. GN's
+# static_library writes the archive to obj/<pkg>/lib<name>.a — for the
+# root pdfium target that's out/Static/obj/libpdfium.a. A thin archive
+# (!<thin>) references absolute .o paths that disappear once the build
+# dir is cleaned, so rustc's rlib bundling fails downstream. mac uses
+# BSD stat (-f%z) rather than GNU stat (-c %s).
+STATIC_A="out/Static/obj/libpdfium.a"
+ls -lh "$STATIC_A"
+file "$STATIC_A"
+MAGIC=$(head -c 7 "$STATIC_A")
+case "$MAGIC" in
+  '!<arch>') echo "OK: libpdfium.a has fat-archive magic" ;;
+  '!<thin>') echo "ERROR: libpdfium.a is a GNU thin archive — pdf_is_complete_lib regressed" >&2; exit 1 ;;
+  *) echo "ERROR: libpdfium.a has unexpected magic '$MAGIC'" >&2; exit 1 ;;
+esac
+MEMBERS=$(ar t "$STATIC_A" | wc -l | tr -d ' ')
+SIZE=$(stat -f%z "$STATIC_A")
+echo "libpdfium.a: $MEMBERS members, $SIZE bytes"
+if [ "$MEMBERS" -lt 100 ]; then
+  echo "ERROR: only $MEMBERS members — expected hundreds for a complete pdfium build" >&2
+  exit 1
+fi
+if [ "$SIZE" -lt 10000000 ]; then
+  echo "ERROR: libpdfium.a is only $SIZE bytes — expected tens of MB for a complete build" >&2
+  exit 1
+fi
+
+echo "[10/$TOTAL] Apply mac shared patch (component -> shared_library)"
+# Layer the shared_library rewrite on top of base so the second ninja
+# pass emits libpdfium.dylib. The Static pass above already produced the
+# archive from the pristine component() target.
+python3 "$REPO_ROOT/pdfium/patches/mac.py" "$PDFIUM" --mode shared
+
+echo "[11/$TOTAL] gn gen out/Release (libpdfium.dylib)"
 # Keep Chromium's bundled libc++ (use_custom_libcxx = true, the default)
 # for the mac dylib — dlopen consumers never see internal __Cr:: symbols
 # so the Chromium-namespaced libc++ inside the shared object is harmless.
 # This mirrors the linux .so path: libcxx overrides apply to the static
-# archive only, because rustc (the only consumer that actually links
-# against internal C++ symbols) can't resolve __Cr::.
+# archive only (out/Static above), because rustc (the only consumer that
+# actually links against internal C++ symbols) can't resolve __Cr::.
 #
 # Setting use_custom_libcxx = false here additionally breaks on Xcode
 # 26.0 / MacOSX26.0.sdk: Chromium's gen/third_party/libc++ module sources
 # still get compiled but miss macros like
 # _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD that are only defined when the
 # bundled libc++ is active, failing with "unknown type name" on every
-# std:: template. A mac static build would need its own out/Static dir
-# with the override isolated to that dir (see build_pdfium.py for the
-# linux version), but this script currently only produces a .dylib.
+# std:: template. That is exactly why the override stays scoped to
+# out/Static and never appears in this heredoc.
 mkdir -p out/Release
 cat > out/Release/args.gn <<EOF
 is_debug = false
@@ -139,19 +213,28 @@ target_os = "mac"
 EOF
 gn gen out/Release
 
-echo "[8/$TOTAL] ninja -C out/Release pdfium"
+echo "[12/$TOTAL] ninja -C out/Release pdfium"
 ninja -C out/Release pdfium
 
-echo "[9/$TOTAL] Verify libpdfium.dylib"
+echo "[13/$TOTAL] Verify libpdfium.dylib"
 ls -lh out/Release/libpdfium.dylib
 file out/Release/libpdfium.dylib
 
-echo "[10/$TOTAL] Stage + tar"
+echo "[14/$TOTAL] Stage + tar + verify"
 mkdir -p "$STAGE_DEST/lib" "$STAGE_DEST/include"
+cp out/Static/obj/libpdfium.a  "$STAGE_DEST/lib/"
 cp out/Release/libpdfium.dylib "$STAGE_DEST/lib/"
-cp out/Release/args.gn        "$STAGE_DEST/args.gn"
-cp -R public/*.h              "$STAGE_DEST/include/"
-cp "$REPO_ROOT/LICENSE"       "$STAGE_DEST/LICENSE"
+cp out/Release/args.gn         "$STAGE_DEST/args.gn"
+cp out/Static/args.gn          "$STAGE_DEST/args.static.gn"
+cp -R public/*.h               "$STAGE_DEST/include/"
+cp "$REPO_ROOT/LICENSE"        "$STAGE_DEST/LICENSE"
 
 tar czf "$ARCHIVE" -C "$STAGING" "$DIR_NAME"
 ls -lh "$ARCHIVE"
+
+# Final gate: reuse the shared verify_archive.sh so the mac .a and .dylib
+# are checked for the FPDF_* public ABI plus the libc++ namespace
+# invariants (std::__Cr:: absent + std::__1:: present in the .a; dylib
+# exempt from the __Cr:: check) exactly like the linux/musl matrix.
+echo "Verifying staged archive with verify_archive.sh"
+bash "$REPO_ROOT/pdfium/scripts/verify_archive.sh" "$ARCHIVE" mac

--- a/pdfium/tests/test_mac_build_script.py
+++ b/pdfium/tests/test_mac_build_script.py
@@ -3,20 +3,25 @@
 The mac build runs on a macos-15 GitHub Actions runner (instead of inside
 the Debian build container used for linux/musl) because PDFium's
 ``gn gen`` invokes ``xcodebuild``, which doesn't exist in Docker. This
-native build path writes its own ``out/Release/args.gn`` heredoc.
+native build path writes its own ``args.gn`` heredocs.
 
-Currently this script only produces a ``libpdfium.dylib`` — a single
-shared-library phase. Internal C++ symbols are resolved inside the
-dylib itself before any ``dlopen`` consumer sees them, so Chromium's
-bundled libc++ (``use_custom_libcxx = true``, the default) is fine and
-we intentionally do *not* override it. This matches the linux .so path
-in ``build_pdfium.py``: libcxx overrides are scoped to the static
-archive only, because rustc is the single consumer that actually links
-against internal C++ symbols and can't resolve ``std::__Cr::``.
+The script runs a two-phase build (mirroring the linux/musl path in
+``build_pdfium.py``): an ``out/Static`` pass with
+``pdf_is_complete_lib = true`` plus the Apple libc++ override
+(``use_custom_libcxx = false``) yields ``libpdfium.a``, then an
+``out/Release`` pass on Chromium's default bundled libc++ yields
+``libpdfium.dylib``.
 
-Setting ``use_custom_libcxx = false`` here additionally broke on
-Xcode 26.0 / MacOSX26.0.sdk (Chromium's libc++ module sources expect
-macros that are only defined when the bundled libc++ is active).
+The libc++ override is scoped to ``out/Static`` only. For the dylib,
+internal C++ symbols are resolved inside the shared object before any
+``dlopen`` consumer sees them, so Chromium's bundled libc++
+(``use_custom_libcxx = true``, the default) is fine and we intentionally
+do *not* override it there. rustc, the single consumer that links
+against internal C++ symbols and can't resolve ``std::__Cr::``, only
+touches the static archive. Setting ``use_custom_libcxx = false`` on the
+dylib pass additionally broke on Xcode 26.0 / MacOSX26.0.sdk (Chromium's
+libc++ module sources expect macros only defined when the bundled libc++
+is active), so keeping it scoped to ``out/Static`` is load-bearing.
 """
 
 import os
@@ -30,12 +35,15 @@ def load_script():
         return f.read()
 
 
-def extract_args_gn_heredoc(sh: str) -> str:
-    # Pull just the `cat > out/Release/args.gn <<EOF ... EOF` block so
-    # assertions test what actually ends up in args.gn, not commentary
-    # in surrounding shell comments.
-    m = re.search(r"cat > out/Release/args\.gn <<EOF\n(.*?)\nEOF\n", sh, re.DOTALL)
-    assert m, "args.gn heredoc not found in build_mac_native.sh"
+def extract_args_gn_heredoc(sh: str, out_dir: str = "out/Release") -> str:
+    # Pull just the `cat > <out_dir>/args.gn <<EOF ... EOF` block so
+    # assertions test what actually ends up in that args.gn, not
+    # commentary in surrounding shell comments. The mac build now writes
+    # two heredocs (out/Static for libpdfium.a, out/Release for the
+    # dylib), so callers pass the dir they want to inspect.
+    pat = r"cat > " + re.escape(out_dir) + r"/args\.gn <<EOF\n(.*?)\nEOF\n"
+    m = re.search(pat, sh, re.DOTALL)
+    assert m, f"{out_dir}/args.gn heredoc not found in build_mac_native.sh"
     return m.group(1)
 
 
@@ -71,3 +79,66 @@ class TestMacBuildScriptXcodePin:
         # script is safe to run locally without modifying the
         # developer's global toolchain.
         assert "export DEVELOPER_DIR=" in self.sh
+
+
+class TestMacBuildScriptStaticArchive:
+    """The mac build now produces libpdfium.a alongside libpdfium.dylib.
+
+    A two-phase build mirrors the linux/musl path: an out/Static pass with
+    pdf_is_complete_lib = true (fat static_library) plus the Apple libc++
+    override, then the out/Release pass for the dylib on Chromium's default
+    bundled libc++. The libc++ override stays scoped to out/Static so the
+    dylib pass never re-triggers the Xcode 26.0 / USE_LIBCXX_MODULES failure.
+    """
+
+    def setup_method(self):
+        self.sh = load_script()
+
+    def test_mac_writes_static_and_release_args(self):
+        # Both heredocs must exist: out/Static for the archive, out/Release
+        # for the dylib.
+        assert "cat > out/Static/args.gn <<EOF" in self.sh
+        assert "cat > out/Release/args.gn <<EOF" in self.sh
+
+    def test_mac_static_args_has_pdf_is_complete_lib(self):
+        # pdf_is_complete_lib = true fires PDFium's own BUILD.gn branch that
+        # emits a fat archive (drops the thin_archive config). Without it,
+        # ar writes a GNU thin archive whose .o paths vanish downstream.
+        static_args = extract_args_gn_heredoc(self.sh, "out/Static")
+        assert "pdf_is_complete_lib = true" in static_args
+
+    def test_mac_static_args_disables_custom_libcxx(self):
+        # The Apple libc++ override (std::__1::) belongs to the static
+        # archive ONLY — rustc links its internal C++ symbols against the
+        # system runtime and cannot resolve Chromium's std::__Cr::.
+        static_args = extract_args_gn_heredoc(self.sh, "out/Static")
+        release_args = extract_args_gn_heredoc(self.sh, "out/Release")
+        assert "use_custom_libcxx = false" in static_args
+        assert "use_custom_libcxx_for_host = false" in static_args
+        # Must NOT leak into the dylib pass (regression guard for the
+        # Xcode 26.0 module compile failure — see
+        # test_dylib_keeps_chromium_bundled_libcxx which pins the same).
+        assert "use_custom_libcxx = false" not in release_args
+        assert "use_custom_libcxx_for_host" not in release_args
+
+    def test_mac_stages_libpdfium_a(self):
+        # The staging step must copy the fat archive from its GN output
+        # path (obj/libpdfium.a) into $STAGE_DEST/lib/ next to the dylib.
+        assert "cp out/Static/obj/libpdfium.a  \"$STAGE_DEST/lib/\"" in self.sh
+        assert "cp out/Release/libpdfium.dylib \"$STAGE_DEST/lib/\"" in self.sh
+        # The static GN args must also ship as args.static.gn (matches the
+        # linux/musl release layout so consumers can inspect both builds).
+        assert 'cp out/Static/args.gn          "$STAGE_DEST/args.static.gn"' in self.sh
+
+    def test_mac_verifies_fat_archive(self):
+        # Build-level gate: reject a GNU thin archive and enforce the
+        # member/size floors (mirrors build_pdfium.py's
+        # VERIFY_COMPLETE_STATIC_LIB). mac uses BSD stat (-f%z).
+        assert "'!<arch>'" in self.sh
+        assert "'!<thin>'" in self.sh
+        assert "stat -f%z" in self.sh
+
+    def test_mac_invokes_verify_archive_script(self):
+        # The script must end by running the shared symbol/namespace gate
+        # over the staged .tgz for the mac platform.
+        assert 'verify_archive.sh" "$ARCHIVE" mac' in self.sh


### PR DESCRIPTION
## What

Adds a static-archive (`libpdfium.a`) build phase to the native mac path so `pdfium-mac-arm64.tgz` ships both `libpdfium.a` and `libpdfium.dylib`. Rust consumers that statically link PDFium (pdfium-render with the `static` feature) previously had no archive to link against on mac.

## How

Mirrors the proven two-phase linux/musl pattern in `build_pdfium.py`, inside `build_mac_native.sh`:

1. **out/Static pass** writes `args.gn` with `pdf_is_complete_lib = true` (fires PDFium's own fat `static_library` branch, dropping the `thin_archive` config) plus `use_custom_libcxx = false` + `use_custom_libcxx_for_host = false` so the archive links Apple's system libc++ (`std::__1::`) that rustc can resolve. The libc++ override is **scoped to `out/Static` only**.
2. **out/Release pass** stays byte-for-byte what it was: Chromium's bundled libc++, so the dylib keeps avoiding the Xcode 26.0 / `USE_LIBCXX_MODULES` compile failure.
3. **Patch split**: `mac.py --mode base` runs before the Static pass (keeps the pristine `component()` so it resolves to `static_library`), then `--mode shared` before the Release pass rewrites it to `shared_library` for the dylib.
4. **Build-level gate** after ninja: reject a GNU thin archive (magic must be `!<arch>`, not `!<thin>`), enforce member (>= 100) and size (>= 10 MB) floors with BSD `stat -f%z`, matching `VERIFY_COMPLETE_STATIC_LIB`.
5. **Final gate**: run `verify_archive.sh $ARCHIVE mac` on the staged `.tgz` so the FPDF_* public ABI and the libc++ namespace invariants (`std::__Cr::` absent + `std::__1::` present in the `.a`; dylib exempt) are checked for both libraries.

## Tests

`extract_args_gn_heredoc` now takes a dir name so both heredocs can be inspected. New regression tests in `test_mac_build_script.py`:

- `test_mac_writes_static_and_release_args`
- `test_mac_static_args_has_pdf_is_complete_lib`
- `test_mac_static_args_disables_custom_libcxx` (asserts the override is in Static only, NOT Release)
- `test_mac_stages_libpdfium_a`
- `test_mac_verifies_fat_archive`
- `test_mac_invokes_verify_archive_script`

Verified RED against the pre-fix script (6 failures), GREEN after (full `pdfium/tests` suite: 166 passed). ruff + `bash -n` + shellcheck clean.

`build.yml`'s mac archive-contents step now also requires `lib/libpdfium.a`. The unconditional "Verify archive symbols" step already routes through `verify_archive.sh`'s `*.a` branch once the archive is present.

## Not run locally

The actual `gn gen` + `ninja` mac build needs a macOS PDFium toolchain (depot_tools + Xcode 26.0 + hours of build), which isn't available in this environment. The script logic, GN args, verify gate, and staging paths are validated by the test suite and static analysis; the archive itself will be produced by the `macos-15` CI runner.

## Out of scope

- mac/x86_64 static build (matrix builds arm64 only, per the issue).
- Code-signing / notarization of a `.a` (not meaningful for an archive of `.o` files).

Closes #22